### PR TITLE
Add format and mount volume capability

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -322,7 +322,6 @@ unit u_nova_utils_zlib
     :   tests/nova/utils/zlib_tests.cc
     ;
 
-
 unit u_nova_guest_HeartBeat
     :   src/nova/guest/HeartBeat.cc
     :   u_nova_db_mysql
@@ -391,6 +390,14 @@ unit u_nova_rpc_Receiver
         u_nova_Log
     ;
 
+unit u_nova_volume
+    :   src/nova/VolumeManager.cc
+    :   u_nova_Log
+        u_nova_process
+    :   tests/nova/guest/volume_tests.cc
+    :   <define>BOOST_TEST_DYN_LINK
+        <testing.launcher>"BOOST_TEST_CATCH_SYSTEM_ERRORS=no "
+    ;
 
 unit u_nova_guest_mysql_MySqlGuestException
     :   src/nova/guest/mysql/MySqlGuestException.cc
@@ -556,6 +563,7 @@ unit u_nova_guest_mysql_MySqlMessageHandler
         u_nova_guest_mysql_MySqlAppStatus
         u_nova_guest_mysql_MySqlApp
         u_nova_guest_monitoring_Monitoring
+        u_nova_volume
     ;
 
 alias guest_lib
@@ -830,4 +838,22 @@ exe centi-pete
         src/centi_pete.cc
     :
         <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+exe format_file
+    :   pch
+        u_nova_volume
+        u_nova_Log
+        tests/format.cc
+
+    :   <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+exe mount_file
+    :   pch
+        u_nova_volume
+        u_nova_Log
+        tests/mount.cc
+
+    :   <linkflags>$(EXE_LINK_FLAGS)
     ;

--- a/debian/guest_sudoers
+++ b/debian/guest_sudoers
@@ -20,7 +20,12 @@ Cmnd_Alias NOVACMDS = /bin/mv,              \
                       /usr/bin/mysqladmin,  \
                       /bin/ps,              \
                       /usr/sbin/update-rc.d, \
-                      /usr/bin/xbstream
+                      /usr/bin/xbstream,    \
+                      /bin/mount,           \
+                      /bin/mkdir,           \
+                      /sbin/blockdev,       \
+                      /sbin/mkfs,           \
+                      /sbin/dumpe2fs
 
 nova ALL=(root) NOPASSWD: SETENV: NOVACMDS
 

--- a/src/nova/VolumeManager.cc
+++ b/src/nova/VolumeManager.cc
@@ -1,0 +1,292 @@
+#include "nova/Log.h"
+#include "nova/process.h"
+#include "nova/VolumeManager.h"
+#include <boost/assign/list_of.hpp>
+#include <boost/format.hpp>
+#include <fstream>
+#include <string>
+
+using std::string;
+using boost::format;
+using namespace std;
+using namespace boost::assign;
+namespace proc = nova::process;
+
+namespace nova {
+
+namespace {  // Begin anonymous namespace
+
+/**---------------------------------------------------------------------------
+ *- VolumeMountPoint
+ *---------------------------------------------------------------------------*/
+
+class VolumeMountPoint {
+    public:
+        VolumeMountPoint(
+            const std::string device_path,
+            const std::string mount_point)
+        :   device_path(device_path),
+            mount_point(mount_point)
+        {
+        }
+
+        ~VolumeMountPoint() {
+        }
+
+        void mount(const std::string volume_fstype,
+                   const std::string mount_options) {
+            // Create directory if it doesn't exist already
+            proc::execute(list_of("/usr/bin/sudo")
+                                 ("mkdir")
+                                 ("-p")
+                                 (mount_point.c_str()));
+            NOVA_LOG_INFO("Mounting Volume...");
+            // TODO (joe.cruz) if no mount_options then no '-o' flag?
+            proc::CommandList cmds = list_of("/usr/bin/sudo")
+                                            ("mount")
+                                            ("-t")
+                                            (volume_fstype.c_str())
+                                            ("-o")
+                                            (mount_options.c_str())
+                                            (device_path.c_str())
+                                            (mount_point.c_str());
+            std::stringstream output;
+            try{
+                proc::execute(output, cmds);
+            }
+            catch (proc::ProcessException &e) {
+                NOVA_LOG_ERROR("Mounting Device FAILED:%s", e.what());
+                NOVA_LOG_ERROR("%s", output.str())
+                throw VolumeException(VolumeException::MOUNT_FAILURE);
+            }
+        }
+
+        void write_to_fstab(const std::string volume_fstype,
+                            const std::string mount_options) {
+            const std::string fstab_file_name = "/etc/fstab";
+            const std::string fstab_original_file_name = "/etc/fstab.orig";
+            const std::string new_fstab_file_name = "/tmp/newfstab";
+
+            std::string fstab_line = str(format(
+                "%s\t%s\t%s\t%s\t0\t0")
+                % device_path.c_str()
+                % mount_point.c_str()
+                % volume_fstype.c_str()
+                % mount_options.c_str()
+                );
+
+            NOVA_LOG_INFO("Writing to fstab...");
+            try {
+                    proc::execute(list_of("/usr/bin/sudo")("cp")
+                                         (fstab_file_name.c_str())
+                                         (fstab_original_file_name.c_str()));
+                    proc::execute(list_of("/usr/bin/sudo")("cp")
+                                         (fstab_file_name.c_str())
+                                         (new_fstab_file_name.c_str()));
+                    proc::execute(list_of("/usr/bin/sudo")("chmod")
+                                         ("666")(new_fstab_file_name.c_str()));
+
+                    ofstream tmp_new_fstab_file;
+                    // Open file in append mode
+                    tmp_new_fstab_file.open(new_fstab_file_name.c_str(), ios::app);
+                    if (!tmp_new_fstab_file.good()) {
+                        NOVA_LOG_ERROR("Couldn't open tmp new fstab file");
+                        throw VolumeException(VolumeException::WRITE_TO_FSTAB_FAILURE);
+                    }
+                    tmp_new_fstab_file << endl;
+                    tmp_new_fstab_file << fstab_line << endl;
+                    tmp_new_fstab_file.close();
+
+                    proc::execute(list_of("/usr/bin/sudo")("chmod")
+                                         ("640")(new_fstab_file_name.c_str()));
+                    proc::execute(list_of("/usr/bin/sudo")("mv")
+                                         (new_fstab_file_name.c_str())
+                                         (fstab_file_name.c_str()));
+            }
+            catch (proc::ProcessException &e) {
+                NOVA_LOG_ERROR("Writing to fstab FAILED:%s", e.what());
+                throw VolumeException(VolumeException::WRITE_TO_FSTAB_FAILURE);
+            }
+        }
+
+    private:
+
+        const std::string device_path;
+        const std::string mount_point;
+};
+
+} // end anonymous namespace
+
+/**---------------------------------------------------------------------------
+ *- VolumeDevice
+ *---------------------------------------------------------------------------*/
+
+
+VolumeDevice::VolumeDevice(
+    const string device_path,
+    const VolumeManager & manager)
+:   device_path(device_path),
+    manager(manager)
+{
+}
+
+VolumeDevice::~VolumeDevice() {
+}
+
+void VolumeDevice::format() {
+    check_device_exists();
+    format_device();
+    check_format();
+}
+
+void VolumeDevice::mount(const std::string mount_point) {
+    VolumeMountPoint volume_mount_point(device_path, mount_point);
+    std::string volume_filesystem_type = manager.get_volume_fstype();
+    std::string mount_options = manager.get_mount_options();
+    volume_mount_point.mount(volume_filesystem_type, mount_options);
+    volume_mount_point.write_to_fstab(volume_filesystem_type, mount_options);
+}
+
+void VolumeDevice::check_device_exists() {
+    NOVA_LOG_INFO("Checking if device exists...");
+    unsigned int attempts = 0;
+    unsigned int max_retries =  manager.get_num_tries_device_exists();
+    // Take into account first attempt for max attempts
+    unsigned int max_attempts = max_retries + 1;
+
+    while(attempts < max_attempts) {
+        std::stringstream output;
+        try{
+            proc::execute(output, list_of("/usr/bin/sudo")
+                                         ("blockdev")
+                                         ("--getsize64")
+                                         (device_path.c_str()));
+            return;
+        }
+        catch (proc::ProcessException &e) {
+            NOVA_LOG_INFO("Checking if device exists FAILED: %s", e.what());
+            attempts++;
+            if (attempts >= max_attempts) {
+                NOVA_LOG_ERROR("Checking if device exists FAILED after (%u) attempts", attempts);
+                NOVA_LOG_ERROR("%s", output.str());
+                throw VolumeException(VolumeException::DEVICE_DOES_NOT_EXIST);
+            }
+        }
+    }
+}
+
+void VolumeDevice::format_device() {
+    NOVA_LOG_INFO("Formatting device...");
+    std::string volume_fstype = manager.get_volume_fstype();
+    std::string format_options = manager.get_format_options();
+    proc::CommandList cmds = list_of("/usr/bin/sudo")
+                                    ("mkfs")("-F")("-t")
+                                    (volume_fstype.c_str())
+                                    (format_options.c_str())
+                                    (device_path.c_str());
+    std::stringstream output;
+    try{
+        proc::execute(output, cmds);
+        // TODO (joe.cruz) expect EOF
+    }
+    catch (proc::ProcessException &e) {
+        NOVA_LOG_ERROR("Formatting Device FAILED:%s", e.what());
+        NOVA_LOG_ERROR("%s", output.str());
+        throw VolumeException(VolumeException::FORMAT_DEVICE_FAILURE);
+    }
+}
+
+void VolumeDevice::check_format() {
+   NOVA_LOG_INFO("Checking device format...");
+    proc::CommandList cmds = list_of("/usr/bin/sudo")
+                                    ("dumpe2fs")
+                                    (device_path.c_str());
+    // proc::Process<proc::StdErrAndStdOut> process(cmds);
+    std::stringstream output;
+    try{
+        proc::execute(output, cmds);
+        // TODO (joe.cruz) expect patterns "has_journal", "Wrong magic number"
+    }
+    catch (proc::ProcessException &e) {
+        NOVA_LOG_ERROR("Check formatting Device FAILED:%s", e.what());
+        NOVA_LOG_ERROR("%s", output.str());
+        throw VolumeException(VolumeException::CHECK_FORMAT_FAILURE);
+    }
+}
+
+
+
+/**---------------------------------------------------------------------------
+ *- VolumeManager
+ *---------------------------------------------------------------------------*/
+
+VolumeManager::VolumeManager(
+    const unsigned int num_tries_device_exists,
+    const std::string & volume_fstype,
+    const std::string & format_options,
+    const unsigned int volume_format_timeout,
+    const std::string & mount_options)
+:   num_tries_device_exists(num_tries_device_exists),
+    volume_fstype(volume_fstype),
+    format_options(format_options),
+    volume_format_timeout(volume_format_timeout),
+    mount_options(mount_options)
+{
+}
+
+VolumeManager::~VolumeManager() {
+}
+
+unsigned int VolumeManager::get_num_tries_device_exists() const {
+    return num_tries_device_exists;
+}
+
+std::string VolumeManager::get_volume_fstype() const {
+    return volume_fstype;
+}
+
+std::string VolumeManager::get_format_options() const {
+    return format_options;
+}
+
+unsigned int VolumeManager::get_volume_format_timeout() const {
+    return volume_format_timeout;
+}
+
+std::string VolumeManager::get_mount_options() const {
+    return mount_options;
+}
+
+VolumeDevice VolumeManager::create_volume_device(const string device_path) {
+    return VolumeDevice(device_path, *this);
+}
+
+/**---------------------------------------------------------------------------
+ *- VolumeException
+ *---------------------------------------------------------------------------*/
+
+VolumeException::VolumeException(Code code) throw()
+: code(code) {
+}
+
+VolumeException::~VolumeException() throw() {
+}
+
+const char * VolumeException::what() const throw() {
+    switch(code) {
+        case DEVICE_DOES_NOT_EXIST:
+            return "Device does not exist after retries.";
+        case FORMAT_DEVICE_FAILURE:
+            return "There was a failure while formatting device.";
+        case CHECK_FORMAT_FAILURE:
+            return "There was a failure checking format of device.";
+        case MOUNT_FAILURE:
+            return "There was a failure mounting device.";
+        case WRITE_TO_FSTAB_FAILURE:
+            return "There was a failure writing to fstab.";
+        default:
+            return "An error occurred.";
+    }
+}
+
+} // end namespace nova

--- a/src/nova/VolumeManager.h
+++ b/src/nova/VolumeManager.h
@@ -1,0 +1,107 @@
+#ifndef __NOVA_VOLUME_MANAGER_H
+#define __NOVA_VOLUME_MANAGER_H
+
+#include <string>
+#include <boost/utility.hpp>
+
+
+namespace nova {
+
+// Forward Declaration so VolumeDevice can take VolumeManager reference
+// Passing VolumeManager since many of its attributes are passed to VolumeDevice
+class VolumeManager;
+
+class VolumeDevice {
+public:
+    VolumeDevice(const std::string device_path,
+                 const VolumeManager & manager);
+
+    ~VolumeDevice();
+
+    /** This runs the entire format process which includes:
+      * check_device_exists
+      * format_device
+      * check_format **/
+    void format();
+
+    /** This runs the entire mount process which includes:
+      * mount device
+      * write to fstab **/
+    void mount(const std::string mount_point);
+
+    /** Check that the device path exists.
+     * Verify that the device path has actually been created and can report
+     * it's size, only then can it be available for formatting, retry
+     * num_tries_device_exists to account for the time lag.  **/
+    void check_device_exists();
+
+    /** Calls mkfs to format the device at device_path.  **/
+    void format_device();
+
+    /** Checks that an unmounted volume is formatted.  **/
+    void check_format();
+
+private:
+
+    const std::string device_path;
+    const VolumeManager & manager;
+
+};
+
+class VolumeManager : boost::noncopyable  {
+public:
+    VolumeManager(const unsigned int num_tries_device_exists,
+                  const std::string & volume_fstype,
+                  const std::string & format_options,
+                  const unsigned int volume_format_timeout,
+                  const std::string & mount_options);
+
+    ~VolumeManager();
+
+    unsigned int get_num_tries_device_exists() const;
+
+    std::string get_volume_fstype() const;
+
+    std::string get_format_options() const;
+
+    unsigned int get_volume_format_timeout() const;
+
+    std::string get_mount_options() const;
+
+    VolumeDevice create_volume_device(const std::string device_path);
+
+
+private:
+
+    const unsigned int num_tries_device_exists;
+    const std::string volume_fstype;
+    const std::string format_options;
+    const unsigned int volume_format_timeout;
+    const std::string mount_options;
+};
+
+typedef boost::shared_ptr<VolumeManager> VolumeManagerPtr;
+
+class VolumeException : public std::exception {
+
+    public:
+        enum Code {
+            DEVICE_DOES_NOT_EXIST,
+            FORMAT_DEVICE_FAILURE,
+            CHECK_FORMAT_FAILURE,
+            MOUNT_FAILURE,
+            WRITE_TO_FSTAB_FAILURE
+        };
+
+        VolumeException(Code code) throw();
+
+        virtual ~VolumeException() throw();
+
+        const Code code;
+
+        virtual const char * what() const throw();
+};
+
+} // end namespace nova
+
+#endif // __NOVA_VOLUME_MANAGER_H

--- a/src/nova/flags.cc
+++ b/src/nova/flags.cc
@@ -470,6 +470,30 @@ size_t FlagValues::status_thread_stack_size() const {
                           (size_t) 1024 * 1024);
 }
 
+bool FlagValues::volume_format_and_mount() const {
+    return get_flag_value<bool>(*map, "volume_format_and_mount", false);
+}
+
+const char * FlagValues::volume_file_system_type() const {
+    return map->get("volume_file_system_type", "ext3");
+}
+
+int FlagValues::volume_check_device_num_retries() const {
+    return get_flag_value<int>(*map, "volume_check_device_num_retries", 3);
+}
+
+const char * FlagValues::volume_format_options() const {
+    return map->get("volume_format_options", "-m 5");
+}
+
+unsigned long FlagValues::volume_format_timeout() const {
+    return get_flag_value(*map, "volume_format_timeout", (unsigned long) 120);
+}
+
+const char * FlagValues::volume_mount_options() const {
+    return map->get("volume_mount_options", "defaults,noatime");
+}
+
 size_t FlagValues::worker_thread_stack_size() const {
     return get_flag_value(*map, "worker_thread_stack_size",
                           (size_t) 1024 * 1024);

--- a/src/nova/flags.h
+++ b/src/nova/flags.h
@@ -188,7 +188,20 @@ class FlagValues {
 
         bool use_syslog() const;
 
+        bool volume_format_and_mount() const;
+
+        const char * volume_file_system_type() const;
+
+        int volume_check_device_num_retries() const;
+
+        const char * volume_format_options() const;
+
+        unsigned long volume_format_timeout() const;
+
+        const char * volume_mount_options() const;
+
         size_t worker_thread_stack_size() const;
+
 
     private:
 

--- a/src/nova/guest/mysql/MySqlMessageHandler.h
+++ b/src/nova/guest/mysql/MySqlMessageHandler.h
@@ -8,6 +8,7 @@
 #include "nova/guest/mysql/MySqlApp.h"
 #include "nova/guest/monitoring/monitoring.h"
 #include <string>
+#include "nova/VolumeManager.h"
 
 
 namespace nova { namespace guest { namespace mysql {
@@ -43,7 +44,9 @@ namespace nova { namespace guest { namespace mysql {
             MySqlAppMessageHandler(
                 MySqlAppPtr mysqlApp,
                 nova::guest::apt::AptGuestPtr apt,
-                nova::guest::monitoring::Monitoring & monitoring);
+                nova::guest::monitoring::Monitoring & monitoring,
+                bool format_and_mount_volume_enabled,
+                VolumeManagerPtr volumeManager);
 
             virtual ~MySqlAppMessageHandler();
 
@@ -51,10 +54,14 @@ namespace nova { namespace guest { namespace mysql {
 
             MySqlAppPtr create_mysql_app();
 
+            VolumeManagerPtr create_volume_manager();
+
         private:
             nova::guest::apt::AptGuestPtr apt;
             nova::guest::monitoring::Monitoring & monitoring;
             MySqlAppPtr mysqlApp;
+            bool format_and_mount_volume_enabled;
+            VolumeManagerPtr volumeManager;
     };
 
 } } }

--- a/src/receiver_daemon.cc
+++ b/src/receiver_daemon.cc
@@ -234,8 +234,29 @@ void initialize_and_run(FlagValues & flags) {
                                       flags.mysql_state_change_wait_time(),
                                       flags.skip_install_for_prepare()));
 
-    MessageHandlerPtr handler_mysql_app(new MySqlAppMessageHandler(
-        mysqlApp, apt_worker, monitoring));
+    /* Create Volume Manager. */
+    VolumeManagerPtr volumeManager(new VolumeManager(
+        flags.volume_check_device_num_retries(),
+        flags.volume_file_system_type(),
+        flags.volume_format_options(),
+        flags.volume_format_timeout(),
+        flags.volume_mount_options()
+    ));
+
+    /** Sneaky Pete formats and mounts volumes based on the bool flag
+      *'volume_format_and_mount' which is passed to MySqlAppMessageHandler which
+      * uses the flag to decide weather to format/mount a volume during the
+      * prepare call */
+    /** TODO (joe.cruz) There has to be a better way of enabling sneaky pete to
+      * format/mount a volume and to create the volume manager based on that.
+      * I did this because currently flags can only be retrived from
+      * receiver_daemon so the volumeManager has to be created here. */
+    MessageHandlerPtr handler_mysql_app(
+        new MySqlAppMessageHandler(mysqlApp,
+                                   apt_worker,
+                                   monitoring,
+                                   flags.volume_format_and_mount(),
+                                   volumeManager));
     handlers.push_back(handler_mysql_app);
 
     /* Create the Interrogator for the guest. */

--- a/tests/format.cc
+++ b/tests/format.cc
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <iostream>
+#include "nova/Log.h"
+#include "nova/VolumeManager.h"
+
+using namespace std;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+using nova::VolumeManager;
+using nova::VolumeDevice;
+
+
+int main(int argc, char **argv)
+{
+    LogApiScope log(LogOptions::simple());
+
+    if (argc < 2) {
+        cerr << "Usage: " << (argc > 0 ? argv[0] : "format_file")
+        << " device_path" << endl;
+        return 1;
+    }
+
+    const unsigned int num_tries_device_exists = 3;
+    const string volume_fstype = "ext3";
+    const string format_options = "-m 5";
+    const unsigned int volume_format_timeout = 120;
+    const string mount_options = "defaults,noatime";
+
+    const string device_path = argv[1];
+
+    /* Create Volume Manager. */
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+
+    NOVA_LOG_INFO("Creating volume device with device_path: %s", device_path.c_str());
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+
+    NOVA_LOG_INFO("Formatting volume device.");
+    vol_device.format();
+
+    NOVA_LOG_INFO("Formatted the volume.");
+
+    return 0;
+}

--- a/tests/mount.cc
+++ b/tests/mount.cc
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <iostream>
+#include "nova/Log.h"
+#include "nova/VolumeManager.h"
+
+using namespace std;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+using nova::VolumeManager;
+using nova::VolumeDevice;
+
+
+int main(int argc, char **argv)
+{
+    LogApiScope log(LogOptions::simple());
+
+    if (argc < 3) {
+        cerr << "Usage: " << (argc > 0 ? argv[0] : "mount_file")
+        << " device_path mount_point" << endl;
+        return 1;
+    }
+
+    const string device_path = argv[1];
+    const string mount_point = argv[2];
+
+    const unsigned int num_tries_device_exists = 3;
+    const string volume_fstype = "ext3";
+    const string format_options = "-m 5";
+    const unsigned int volume_format_timeout = 120;
+    const string mount_options = "defaults,noatime";
+
+    /* Create Volume Manager. */
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+
+    NOVA_LOG_INFO("Creating volume device with device_path: %s", device_path.c_str());
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+
+    NOVA_LOG_INFO("Mounting volume device to: %s", mount_point.c_str());
+    vol_device.mount(mount_point);
+
+    NOVA_LOG_INFO("Mounted the volume.");
+
+    return 0;
+}

--- a/tests/nova/guest/volume_tests.cc
+++ b/tests/nova/guest/volume_tests.cc
@@ -1,0 +1,101 @@
+#define BOOST_TEST_MODULE volume_tests
+#include <boost/test/unit_test.hpp>
+
+#include "nova/Log.h"
+#include "nova/VolumeManager.h"
+#include <string>
+
+using namespace nova;
+using nova::VolumeManager;
+using nova::VolumeDevice;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+
+
+/* These are currently negative tests to test out proper exceptions are thrown
+ * and handled related to volume formatting and mounting.
+ * All test cases use bad device paths and mount points to trigger bad return
+ * codes for formatting and mouting processes.
+ */
+
+
+#define CHECK_VOLUME_EXCEPTION(statement, ex_code) try { \
+        statement ; \
+        BOOST_FAIL("Should have thrown."); \
+    } catch(const VolumeException & ve) { \
+        BOOST_REQUIRE_EQUAL(ve.code, VolumeException::ex_code); \
+    }
+
+
+const std::string device_path= "/DEVICE_DOESNT_EXIST";
+const std::string mount_point= "/MOUNT_POINT_DOESNT_EXIST";
+
+const unsigned int num_tries_device_exists = 3;
+const std::string volume_fstype = "ext3";
+const std::string format_options = "-m 5";
+const unsigned int volume_format_timeout = 120;
+const std::string mount_options = "defaults,noatime";
+
+
+BOOST_AUTO_TEST_CASE(check_device_exists_test)
+{
+    LogApiScope log(LogOptions::simple());
+
+
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+    CHECK_VOLUME_EXCEPTION(vol_device.check_device_exists(), DEVICE_DOES_NOT_EXIST);
+}
+
+
+BOOST_AUTO_TEST_CASE(format_device_test)
+{
+    LogApiScope log(LogOptions::simple());
+
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+    CHECK_VOLUME_EXCEPTION(vol_device.format_device(), FORMAT_DEVICE_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(check_format_test)
+{
+    LogApiScope log(LogOptions::simple());
+
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+    CHECK_VOLUME_EXCEPTION(vol_device.check_format(), CHECK_FORMAT_FAILURE);
+}
+
+BOOST_AUTO_TEST_CASE(mount_test)
+{
+    LogApiScope log(LogOptions::simple());
+
+    VolumeManager volumeManager(
+        num_tries_device_exists,
+        volume_fstype,
+        format_options,
+        volume_format_timeout,
+        mount_options
+    );
+    VolumeDevice vol_device = volumeManager.create_volume_device(device_path);
+    CHECK_VOLUME_EXCEPTION(vol_device.mount(mount_point), MOUNT_FAILURE);
+}


### PR DESCRIPTION
If a cinder volume is created for a trove instance, in order to
use it for /var/lib/mysql (or any directory specified in the config)
it requires the agent to format and mount the volume to the specfied
path.

Formatting and mounting of volume occurs within the "prepare" message
handler.

This feature can be enabled with the 'volume_format_and_mount' flag.
