### PR TITLE
updating rackspace-monitoring-agent api call

### DIFF
--- a/src/nova/guest/monitoring/Monitoring.cc
+++ b/src/nova/guest/monitoring/Monitoring.cc
@@ -90,6 +90,11 @@ void Monitoring::install_and_configure_monitoring_agent(
     apt.install(agent_package_name.c_str(), agent_install_timeout);
 }
 
+void Monitoring::update_monitoring_agent(nova::guest::apt::AptGuest & apt) const{
+    NOVA_LOG_DEBUG("update_monitoring_agent call ");
+    apt.install(agent_package_name.c_str(), agent_install_timeout);
+}
+
 void Monitoring::remove_monitoring_agent(AptGuest & apt) const {
     stop_monitoring_agent();
     NOVA_LOG_DEBUG("remove_monitoring_agent call ");

--- a/src/nova/guest/monitoring/MonitoringMessageHandler.cc
+++ b/src/nova/guest/monitoring/MonitoringMessageHandler.cc
@@ -62,6 +62,10 @@ JsonDataPtr MonitoringMessageHandler::handle_message(const GuestInput & input) {
         NOVA_LOG_DEBUG("handling the remove_monitoring_agent method");
         monitoring.remove_monitoring_agent(*apt);
         return JsonData::from_null();
+    } else if (input.method_name == "update_monitoring_agent") {
+        NOVA_LOG_DEBUG("handling the update_monitoring_agent method");
+        monitoring.update_monitoring_agent(*apt);
+        return JsonData::from_null();
     } else if (input.method_name == "start_monitoring_agent") {
         NOVA_LOG_DEBUG("handling the start_monitoring_agent method");
         monitoring.start_monitoring_agent();

--- a/src/nova/guest/monitoring/monitoring.h
+++ b/src/nova/guest/monitoring/monitoring.h
@@ -30,6 +30,10 @@ namespace nova { namespace guest { namespace monitoring {
             void remove_monitoring_agent(
                 nova::guest::apt::AptGuest & apt) const;
 
+            /* Updates the monitoring agent from the guest */
+            void update_monitoring_agent(
+                nova::guest::apt::AptGuest & apt) const;
+
             void start_monitoring_agent() const;
 
             void stop_monitoring_agent() const;


### PR DESCRIPTION
This adds a method from an RPC call to allow a monitoring agent to be update
to the latest version. This is a trivial change that just issues an
'apt-get install rackspace-monitoring-agent' to install the latest version.
