### PR TITLE
Adds ResilientSender class and Conductor driver

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -608,6 +608,21 @@ unit-test send_and_receive
     ;
 explicit send_and_receive ;
 
+# Requires RabbitMQ server to be installed and running on localhost.
+unit-test resilient_tests
+    :   pch
+        u_nova_flags
+        u_nova_guest_GuestException
+        u_nova_rpc_Receiver
+        u_nova_rpc_Sender
+        u_nova_json
+        tests/resilient_tests.cc
+        test_dependencies
+    :   <define>BOOST_TEST_DYN_LINK
+        <testing.launcher>"BOOST_TEST_CATCH_SYSTEM_ERRORS=no valgrind --leak-check=full --track-origins=yes -v"
+    ;
+explicit resilient_tests ;
+
 
 # Requires MySQL to be installed with valid values in my.cnf.
 # Run by setting an environment variable named "TEST_ARGS" to whatever nova
@@ -838,4 +853,62 @@ exe mount_file
         tests/mount.cc
 
     :   <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+# And run this one to put a message on the conductor queue.
+exe send_to_conductor
+    :   pch
+        static_dependencies
+        u_nova_process
+        u_nova_rpc_Sender
+        src/send_to_conductor.cc
+    :
+        <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+# And run this one to show ResilientRec works.
+exe demo_rreceiver
+    :   pch
+        static_dependencies
+        u_nova_process
+        u_nova_rpc_Receiver
+        src/demo_rreceiver.cc
+    :
+        <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+# An agent designed to exercise the Resilient sender and receiver until it's told to stop.
+exe send_forever_turbo
+    :   pch
+        static_dependencies
+        empty_agent_lib
+        u_nova_process
+        u_nova_rpc_Sender
+        src/send_forever_turbo.cc
+    :
+        <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+exe sfturbo_send
+    :   pch
+        static_dependencies
+        empty_agent_lib
+        u_nova_process
+        u_nova_rpc_Sender
+        u_nova_rpc_Receiver
+        src/sfturbo_send.cc
+    :
+        <linkflags>$(EXE_LINK_FLAGS)
+    ;
+
+exe sfturbo_recv
+    :   pch
+        static_dependencies
+        empty_agent_lib
+        u_nova_process
+        u_nova_rpc_Sender
+        u_nova_rpc_Receiver
+        src/sfturbo_recv.cc
+    :
+        <linkflags>$(EXE_LINK_FLAGS)
     ;

--- a/src/demo_rreceiver.cc
+++ b/src/demo_rreceiver.cc
@@ -1,0 +1,54 @@
+#include "nova/Log.h"
+#include "nova/rpc/receiver.h"
+#include <boost/format.hpp>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace boost;
+using nova::JsonData;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+
+// Repeatedly recieve and print messages on a specific topic.
+// ./demo_rreceiver guest f7999d1955c5014aa32c guest restests
+
+//using namespace nova;
+using namespace nova::rpc;
+
+int main(int argc, char **argv)
+{
+  LogApiScope log(LogOptions::simple());
+
+  if (argc < 4) {
+    cerr << "Usage: demo_rreceiver <user> <password> <topic> <exchange>" << endl;
+    return 1;
+  }
+
+  int i = 0;
+  const char * userid = argv[++i];
+  const char * password = argv[++i];
+  const char * topic = argv[++i];
+  const char * exchange = argv[++i];
+
+  ResilientReceiver receiver("localhost", 5672, userid, password, 4096, topic, exchange, 10);
+
+  while(true){
+        nova::guest::GuestInput input = receiver.next_message();
+        cout << input.args->to_string() << endl;
+
+        nova::guest::GuestOutput output;
+        output.failure = boost::none;
+        output.result = JsonData::from_string("ok");
+
+        receiver.finish_message(output);
+  }
+
+  return 0;
+}
+

--- a/src/mysql_agent.cc
+++ b/src/mysql_agent.cc
@@ -84,9 +84,18 @@ struct Func {
         MessageHandlerPtr handler_apt(new AptMessageHandler(apt_worker));
         handlers.push_back(handler_apt);
 
+        /* Create Conductor connection. */
+        ResilientSenderPtr sender(new ResilientSender(
+            flags.rabbit_host(), flags.rabbit_port(),
+            flags.rabbit_userid(), flags.rabbit_password(),
+            flags.rabbit_client_memory(), flags.conductor_queue(),
+            flags.control_exchange(),
+            flags.rabbit_reconnect_wait_time()));
+
         /* Create MySQL updater. */
         MySqlAppStatusPtr mysql_status_updater(new MySqlAppStatus(
             nova_db,
+            sender,
             flags.nova_db_reconnect_wait_time(),
             flags.guest_id()));
 
@@ -148,6 +157,7 @@ struct Func {
         /* Backup task */
         BackupManager backup(
                       nova_db,
+                      sender,
                       job_runner,
                       flags.backup_process_commands(),
                       flags.backup_segment_max_size(),

--- a/src/nova/Log.cc
+++ b/src/nova/Log.cc
@@ -175,7 +175,7 @@ LogPtr Log::get_instance() {
 void Log::handle_fmt_error(const char * filename, const int line_number,
                            const char * fmt_string,
                            const boost::io::format_error & fe) {
-    boost::format fmt("! FORMAT ERROR for sting %s: %s");
+    boost::format fmt("! FORMAT ERROR for string %s: %s");
     const std::string msg(str(fmt % fmt_string % fe.what()));
     nova::Log::get_instance()->write(filename, line_number, LEVEL_ERROR,
                                      msg.c_str());

--- a/src/nova/Log.h
+++ b/src/nova/Log.h
@@ -202,6 +202,5 @@ namespace nova {
 #define NOVA_LOG_TRACE(fmt, ...) { ::nova::Log::get_instance()->write( \
     __FILE__, __LINE__, nova::Log::LEVEL_TRACE, fmt, ##__VA_ARGS__); }
 
-
 #endif
 

--- a/src/nova/flags.cc
+++ b/src/nova/flags.cc
@@ -503,4 +503,8 @@ bool FlagValues::use_syslog() const {
     return get_flag_value<bool>(*map, "use_syslog", false);
 }
 
+const char * FlagValues::conductor_queue() const {
+    return map->get("conductor_queue", "trove-conductor");
+}
+
 } } // end nova::flags

--- a/src/nova/flags.h
+++ b/src/nova/flags.h
@@ -202,6 +202,7 @@ class FlagValues {
 
         size_t worker_thread_stack_size() const;
 
+        const char * conductor_queue() const;
 
     private:
 

--- a/src/nova/guest/agent.cc
+++ b/src/nova/guest/agent.cc
@@ -74,7 +74,7 @@ GuestOutput run_method(vector<MessageHandlerPtr> & handlers, GuestInput & input)
     return output;
 }
 
-void message_loop(ResilentReceiver & receiver,
+void message_loop(ResilientReceiver & receiver,
                   vector<MessageHandlerPtr> & handlers) {
     while(true) {
 #ifndef _DEBUG

--- a/src/nova/guest/agent.h
+++ b/src/nova/guest/agent.h
@@ -101,7 +101,7 @@ void run_json_method(std::vector<MessageHandlerPtr> & handlers,
 GuestOutput run_method(std::vector<MessageHandlerPtr> & handlers,
                        GuestInput & input);
 
-void message_loop(nova::rpc::ResilentReceiver & receiver,
+void message_loop(nova::rpc::ResilientReceiver & receiver,
                   std::vector<MessageHandlerPtr> & handlers);
 
 
@@ -186,7 +186,7 @@ void initialize_and_run(const char * const title,
         // appears to avert this phenomenon.
         boost::this_thread::sleep(boost::posix_time::seconds(3));
 
-        nova::rpc::ResilentReceiver receiver(flags.rabbit_host(), flags.rabbit_port(),
+        nova::rpc::ResilientReceiver receiver(flags.rabbit_host(), flags.rabbit_port(),
                     flags.rabbit_userid(), flags.rabbit_password(),
                     flags.rabbit_client_memory(), topic.c_str(),
                     flags.control_exchange(),

--- a/src/nova/guest/backup/BackupManager.cc
+++ b/src/nova/guest/backup/BackupManager.cc
@@ -39,6 +39,8 @@ using nova::utils::swift::SwiftClient;
 using nova::utils::swift::SwiftFileInfo;
 using nova::utils::swift::SwiftUploader;
 using namespace nova::guest::diagnostics;
+using nova::rpc::ResilientSenderPtr;
+
 namespace zlib = nova::utils::zlib;
 
 namespace nova { namespace guest { namespace backup {
@@ -88,7 +90,7 @@ class CabooseChecker {
 /* Calls xtrabackup and presents an interface to be used as a zlib source. */
 class XtraBackupReader : public zlib::InputStream {
 public:
-    XtraBackupReader(CommandList cmds, size_t zlib_buffer_size, 
+    XtraBackupReader(CommandList cmds, size_t zlib_buffer_size,
         optional<double> time_out)
     :   buffer(new char [zlib_buffer_size]),
         last_stdout_write_length(0),
@@ -192,6 +194,7 @@ class BackupJob : public nova::utils::Job {
 public:
     BackupJob(
         MySqlConnectionWithDefaultDbPtr infra_db,
+        ResilientSenderPtr sender,
         const CommandList commands,
         const int & segment_max_size,
         const string & swift_container,
@@ -200,9 +203,10 @@ public:
         const string & tenant,
         const string & token,
         const size_t & zlib_buffer_size,
-        const string & backup_id)
-    :   backup_id(backup_id),
+        const BackupInfo & backup_info)
+    :   backup_info(backup_info),
         infra_db(infra_db),
+        sender(sender),
         commands(commands),
         segment_max_size(segment_max_size),
         swift_container(swift_container),
@@ -216,8 +220,9 @@ public:
     // Copy constructor is designed mainly so we can pass instances
     // from one thread to another.
     BackupJob(const BackupJob & other)
-    :   backup_id(other.backup_id),
+    :   backup_info(other.backup_info),
         infra_db(other.infra_db),
+        sender(other.sender),
         commands(other.commands),
         segment_max_size(other.segment_max_size),
         swift_container(other.swift_container),
@@ -244,7 +249,7 @@ public:
             // Start process
             // As we read, write to Swift
             dump();
-            NOVA_LOG_INFO("Backup comleted without throwing errors.");
+            NOVA_LOG_INFO("Backup completed without throwing errors.");
         } catch(const std::exception & ex) {
             NOVA_LOG_ERROR("Error running backup!");
             NOVA_LOG_ERROR("Exception: %s", ex.what());
@@ -270,8 +275,9 @@ private:
         const float size;
     };
 
-    const string backup_id;
+    const BackupInfo backup_info;
     MySqlConnectionWithDefaultDbPtr infra_db;
+    ResilientSenderPtr sender;
     const CommandList commands;
     const int segment_max_size;
     const string swift_container;
@@ -292,7 +298,7 @@ private:
         BackupProcessReader reader(commands, zlib_buffer_size, time_out);
 
         // Setup SwiftClient
-        SwiftFileInfo file_info(swift_url, swift_container, backup_id);
+        SwiftFileInfo file_info(swift_url, swift_container, backup_info.id.c_str());
         SwiftUploader writer(token, segment_max_size, file_info);
 
         // Save the backup information to the database in case of failure
@@ -327,9 +333,11 @@ private:
         }
     }
 
+
     optional<string> get_state() {
         auto query = str(format("SELECT state FROM backups WHERE id='%s' "
-                                "AND tenant_id='%s';") % backup_id % tenant);
+                                "AND tenant_id='%s';")
+                         % backup_info.id.c_str() % tenant);
         MySqlResultSetPtr result = infra_db->query(query.c_str());
         if (result->next()) {
             auto state = result->get_string(0);
@@ -340,33 +348,44 @@ private:
         return boost::none;
     }
 
-
     void update_db(const string & state,
                    const optional<const DbInfo> & extra_info = boost::none) {
-        const char * text =
-            (!extra_info) ? "UPDATE backups SET updated=?, state=? "
-                            "WHERE id=? AND tenant_id=?"
-                          : "UPDATE backups SET updated=?, state=?, "
-                            "checksum=?, backup_type=?, location=?, "
-                            "size=? "
-                            "WHERE id=? AND tenant_id=?";
-        auto stmt = infra_db->prepare_statement(text);
+
         IsoDateTime now;
-        unsigned int index = 0;
-        stmt->set_string(index ++, now.c_str());
-        stmt->set_string(index ++, state.c_str());
-        if (extra_info) {
-            stmt->set_string(index ++, extra_info->checksum.c_str());
-            stmt->set_string(index ++, extra_info->type.c_str());
-            stmt->set_string(index ++, extra_info->location.c_str());
-            stmt->set_float(index ++, extra_info->size);
+
+        if(extra_info) {
+            stringstream msg;
+            msg << "{"
+                "\"method\": \"update_backup\", "
+                "\"args\": { "
+                     "\"instance_id\": \"" << backup_info.instance_id << "\", "
+                     "\"backup_id\": \"" << backup_info.id << "\", "
+                     "\"updated\": \"" << now.c_str() << "\", "
+                     "\"checksum\": \"" << extra_info->checksum << "\", "
+                     "\"backup_type\": \"" << extra_info->type << "\", "
+                     "\"location\": \"" << extra_info->location << "\", "
+                     "\"size\": \"" << extra_info->size << "\", "
+                     "\"state\": \"" << state << "\""
+                "}"
+            "}";
+            sender->send(msg.str().c_str());
+        } else {
+            stringstream msg;
+            msg << "{"
+                "\"method\": \"update_backup\", "
+                "\"args\": { "
+                     "\"instance_id\": \"" << backup_info.instance_id << "\", "
+                     "\"backup_id\": \"" << backup_info.id << "\", "
+                     "\"updated\": \"" << now.c_str() << "\", "
+                     "\"state\": \"" << state << "\""
+                "}"
+            "}";
+            sender->send(msg.str().c_str());
         }
-        stmt->set_string(index ++, backup_id.c_str());
-        stmt->set_string(index ++, tenant.c_str());
-        stmt->execute(0);
-        NOVA_LOG_INFO("Updating backup %s to state %s", backup_id.c_str(),
+        NOVA_LOG_INFO("Updated backup %s to state %s", backup_info.id.c_str(),
                        state.c_str());
     }
+
 };
 
 
@@ -379,13 +398,16 @@ private:
 
 BackupManager::BackupManager(
     MySqlConnectionWithDefaultDbPtr & infra_db,
+    ResilientSenderPtr sender,
     JobRunner & runner,
     const CommandList commands,
     const int segment_max_size,
     const string swift_container,
     const double time_out,
     const int zlib_buffer_size)
-:   infra_db(infra_db),
+:
+    infra_db(infra_db),
+    sender(sender),
     commands(commands),
     runner(runner),
     segment_max_size(segment_max_size),
@@ -401,16 +423,16 @@ BackupManager::~BackupManager() {
 void BackupManager::run_backup(const string & swift_url,
                         const string & tenant,
                         const string & token,
-                        const string & backup_id) {
+                        const BackupInfo & backup_info) {
     NOVA_LOG_INFO("Starting backup for tenant %s, backup_id=%d",
-                   tenant.c_str(), backup_id.c_str());
+                   tenant.c_str(), backup_info.id.c_str());
     #ifdef _DEBUG
         NOVA_LOG_INFO("Token = %s", token.c_str());
     #endif
 
-    BackupJob job(infra_db, commands, segment_max_size,
+    BackupJob job(infra_db, sender, commands, segment_max_size,
                   swift_container, swift_url, time_out, tenant, token,
-                  zlib_buffer_size, backup_id);
+                  zlib_buffer_size, backup_info);
     runner.run(job);
 }
 

--- a/src/nova/guest/backup/BackupManager.h
+++ b/src/nova/guest/backup/BackupManager.h
@@ -12,14 +12,26 @@
 #include "nova/utils/swift.h"
 #include "nova/utils/threads.h"
 #include <boost/utility.hpp>
+#include "nova/rpc/sender.h"
 
 namespace nova { namespace guest { namespace backup {
 
+    struct BackupInfo {
+        const std::string backup_type;
+        const std::string checksum;
+        const std::string description;
+        const std::string id;
+        const std::string instance_id;
+        const std::string location;
+        const std::string name;
+
+    };
 
     class BackupManager : boost::noncopyable {
         public:
             BackupManager(
                    nova::db::mysql::MySqlConnectionWithDefaultDbPtr & infra_db,
+                   nova::rpc::ResilientSenderPtr sender,
                    nova::utils::JobRunner & runner,
                    const nova::process::CommandList commands,
                    const int segment_max_size,
@@ -32,11 +44,12 @@ namespace nova { namespace guest { namespace backup {
             void run_backup(const std::string & swift_url,
                             const std::string & tenant,
                             const std::string & token,
-                            const std::string & backup_id);
+                            const BackupInfo & backup_info);
 
 
         private:
             nova::db::mysql::MySqlConnectionWithDefaultDbPtr infra_db;
+            nova::rpc::ResilientSenderPtr sender;
             const nova::process::CommandList commands;
             nova::utils::JobRunner & runner;
             const int segment_max_size;
@@ -45,6 +58,7 @@ namespace nova { namespace guest { namespace backup {
             const double time_out;
             const int zlib_buffer_size;
     };
+
 
 } } }  // end namespace
 

--- a/src/nova/guest/backup/BackupMessageHandler.cc
+++ b/src/nova/guest/backup/BackupMessageHandler.cc
@@ -17,6 +17,21 @@ using namespace boost;
 
 namespace nova { namespace guest { namespace backup {
 
+
+BackupInfo from_json(const nova::JsonObjectPtr data){
+    BackupInfo info = {
+        data->get_optional_string("backup_type").get_value_or(""),
+        data->get_optional_string("checksum").get_value_or(""),
+        data->get_optional_string("description").get_value_or(""),
+        data->get_optional_string("id").get_value_or(""),
+        data->get_optional_string("instance_id").get_value_or(""),
+        data->get_optional_string("location").get_value_or(""),
+        data->get_optional_string("name").get_value_or("")
+    };
+    return info;
+}
+
+
 BackupMessageHandler::BackupMessageHandler(BackupManager & backup_manager)
 : backup_manager(backup_manager) {
 }
@@ -26,7 +41,7 @@ JsonDataPtr BackupMessageHandler::handle_message(const GuestInput & input) {
     NOVA_LOG_DEBUG("entering the handle_message method now ");
     if (input.method_name == "create_backup") {
         NOVA_LOG_DEBUG("handling the create_backup method");
-        const auto id = input.args->get_string("backup_id");
+        const auto info = from_json(input.args->get_object("backup_info"));
         const auto swift_url = input.args->get_string("swift_url");
         if (!input.tenant) {
             NOVA_LOG_ERROR("Tenant was not specified by this RPC call! "
@@ -40,7 +55,7 @@ JsonDataPtr BackupMessageHandler::handle_message(const GuestInput & input) {
         }
         const auto tenant = input.tenant.get();
         const auto token = input.token.get();
-        backup_manager.run_backup(swift_url, tenant, token, id);
+        backup_manager.run_backup(swift_url, tenant, token, info);
         return JsonData::from_null();
     } else {
         return JsonDataPtr();

--- a/src/nova/guest/backup/BackupMessageHandler.h
+++ b/src/nova/guest/backup/BackupMessageHandler.h
@@ -7,12 +7,14 @@
 
 namespace nova { namespace guest { namespace backup {
 
+    BackupInfo from_json(const nova::JsonObjectPtr data);
+
     class BackupMessageHandler : public nova::guest::MessageHandler {
 
         public:
           BackupMessageHandler(BackupManager & backup_manager);
-
           virtual nova::JsonDataPtr handle_message(const GuestInput & input);
+
 
         private:
           BackupMessageHandler(const BackupMessageHandler &);

--- a/src/nova/guest/mysql/MySqlAppStatus.cc
+++ b/src/nova/guest/mysql/MySqlAppStatus.cc
@@ -10,6 +10,7 @@
 #include "nova/guest/mysql/MySqlGuestException.h"
 #include <boost/optional.hpp>
 #include "nova/process.h"
+#include "nova/rpc/sender.h"
 #include "nova/utils/regex.h"
 #include <boost/thread.hpp>
 #include "nova/guest/utils.h"
@@ -31,6 +32,7 @@ using nova::utils::Regex;
 using nova::utils::RegexMatchesPtr;
 using std::string;
 using std::stringstream;
+using nova::rpc::ResilientSenderPtr;
 
 namespace io = nova::utils::io;
 namespace utils = nova::guest::utils;
@@ -52,18 +54,19 @@ bool MySqlAppStatusContext::is_file(const char * file_path) const {
     return io::is_file(file_path);
 }
 
-MySqlAppStatus::MySqlAppStatus(MySqlConnectionWithDefaultDbPtr
-                                       nova_db_connection,
-                                   unsigned long nova_db_reconnect_wait_time,
-                                   const char * guest_id,
-                                   MySqlAppStatusContext * context)
+MySqlAppStatus::MySqlAppStatus(MySqlConnectionWithDefaultDbPtr nova_db_connection,
+                               ResilientSenderPtr sender,
+                               unsigned long nova_db_reconnect_wait_time,
+                               const char * guest_id,
+                               MySqlAppStatusContext * context)
 : context(context),
   guest_id(guest_id),
   nova_db(nova_db_connection),
   nova_db_mutex(),
   nova_db_reconnect_wait_time(nova_db_reconnect_wait_time),
   restart_mode(false),
-  status(boost::none)
+  status(boost::none),
+  sender(sender)
 {
     struct F : MySqlAppStatusFunctor {
         MySqlAppStatus * updater;
@@ -205,8 +208,6 @@ void MySqlAppStatus::repeatedly_attempt_to_set_status(Status status) {
     F f;
     f.status = status;
     f.updater = this;
-    // f->updater = this;
-    // f->status = get_actual_db_status();
     repeatedly_attempt_mysql_method(f);
 }
 
@@ -233,30 +234,16 @@ void MySqlAppStatus::repeatedly_attempt_mysql_method(
 
 void MySqlAppStatus::set_status(MySqlAppStatus::Status status) {
     const char * description = status_name(status);
-    Status state = status;
     NOVA_LOG_INFO("Updating MySQL app status to %d (%s).", ((int)status),
                    description);
-    IsoDateTime now;
-    MySqlPreparedStatementPtr stmt;
-    if (get_status_from_nova_db() == boost::none) {
-        NOVA_LOG_INFO("Inserting new Guest status row. Why wasn't this there?");
-        stmt = nova_db->prepare_statement(
-            "INSERT INTO service_statuses "
-            "(instance_id, status_id, status_description) "
-            "VALUES(?, ?, ?) ");
-        stmt->set_string(0, guest_id);
-        stmt->set_int(1, (int)state);
-        stmt->set_string(2, description);
-    } else {
-        stmt = nova_db->prepare_statement(
-            "UPDATE service_statuses "
-            "SET status_description=?, status_id=? "
-            "WHERE instance_id=?");
-        stmt->set_string(0, description);
-        stmt->set_int(1, (int) state);
-        stmt->set_string(2, guest_id);
-    }
-    stmt->execute(0);
+
+    string msg = str(format("{\"method\": \"heartbeat\", "
+                             "\"args\": { "
+                                 "\"instance_id\": \"%s\", "
+                                 "\"payload\": { "
+                                     "\"service_status\": \"%s\"}}}") %
+                     guest_id % description);
+    sender->send(msg.c_str());
     this->status = optional<int>(status);
 }
 

--- a/src/nova/guest/mysql/MySqlAppStatus.h
+++ b/src/nova/guest/mysql/MySqlAppStatus.h
@@ -3,12 +3,12 @@
 
 #include <list>
 #include "nova/db/mysql.h"
+#include "nova/rpc/sender.h"
 #include <boost/thread/mutex.hpp>
 #include <boost/optional.hpp>
 #include <memory>
 #include <sstream>
 #include <string>
-
 
 namespace nova { namespace guest { namespace mysql {
 
@@ -63,6 +63,7 @@ namespace nova { namespace guest { namespace mysql {
 
             MySqlAppStatus(nova::db::mysql::MySqlConnectionWithDefaultDbPtr
                                  nova_db,
+                             nova::rpc::ResilientSenderPtr sender,
                              unsigned long nova_db_reconnect_wait_time,
                              const char * guest_id,
                              MySqlAppStatusContext * context
@@ -149,6 +150,8 @@ namespace nova { namespace guest { namespace mysql {
             bool restart_mode;
 
             boost::optional<Status> status;
+
+            nova::rpc::ResilientSenderPtr sender;
     };
 
     typedef boost::shared_ptr<MySqlAppStatus> MySqlAppStatusPtr;

--- a/src/nova/rpc/Receiver.cc
+++ b/src/nova/rpc/Receiver.cc
@@ -190,10 +190,10 @@ GuestInput Receiver::next_message() {
 
 
 /**---------------------------------------------------------------------------
- *- ResilentReceiver
+ *- ResilientReceiver
  *---------------------------------------------------------------------------*/
 
-ResilentReceiver::ResilentReceiver(const char * host, int port,
+ResilientReceiver::ResilientReceiver(const char * host, int port,
     const char * userid, const char * password, size_t client_memory,
     const char * topic, const char * exchange_name,
     unsigned long reconnect_wait_time)
@@ -210,15 +210,15 @@ ResilentReceiver::ResilentReceiver(const char * host, int port,
     open(false);
 }
 
-ResilentReceiver::~ResilentReceiver() {
+ResilientReceiver::~ResilientReceiver() {
     close();
 }
 
-void ResilentReceiver::close() {
+void ResilientReceiver::close() {
     receiver.reset(0);
 }
 
-void ResilentReceiver::finish_message(const GuestOutput & output) {
+void ResilientReceiver::finish_message(const GuestOutput & output) {
     while(true) {
         try {
             NOVA_LOG_INFO("Finishing message.");
@@ -231,7 +231,7 @@ void ResilentReceiver::finish_message(const GuestOutput & output) {
     }
 }
 
-GuestInput ResilentReceiver::next_message() {
+GuestInput ResilientReceiver::next_message() {
     while(true) {
         try {
             NOVA_LOG_INFO("Waiting for next message...");
@@ -243,7 +243,7 @@ GuestInput ResilentReceiver::next_message() {
     }
 }
 
-void ResilentReceiver::open(bool wait_first) {
+void ResilientReceiver::open(bool wait_first) {
     while(receiver.get() == 0) {
         try {
             if (wait_first) {
@@ -254,6 +254,10 @@ void ResilentReceiver::open(bool wait_first) {
             AmqpConnectionPtr connection =
                 AmqpConnection::create(host.c_str(), port, userid.c_str(),
                     password.c_str(), client_memory);
+
+            Receiver rcv(connection, topic.c_str(), exchange_name.c_str());
+            
+
             receiver.reset(new Receiver(connection, topic.c_str(),
                                         exchange_name.c_str()));
             return;
@@ -265,7 +269,7 @@ void ResilentReceiver::open(bool wait_first) {
     }
 }
 
-void ResilentReceiver::reset() {
+void ResilientReceiver::reset() {
     close();
     open(true);
 }

--- a/src/nova/rpc/Sender.cc
+++ b/src/nova/rpc/Sender.cc
@@ -41,3 +41,81 @@ void Sender::send(const JsonObject & publish_object) {
     NOVA_LOG_INFO("Sending message: %s", publish_object.to_string());
     send(publish_object.to_string());
 }
+
+/**---------------------------------------------------------------------------
+ *- ResilientSender
+ *---------------------------------------------------------------------------*/
+
+ResilientSender::ResilientSender(const char * host, int port,
+    const char * userid, const char * password, size_t client_memory,
+    const char * topic, const char * exchange_name,
+    unsigned long reconnect_wait_time)
+: client_memory(client_memory),
+  exchange_name(exchange_name),
+  host(host),
+  password(password),
+  port(port),
+  sender(0),
+  topic(topic),
+  userid(userid),
+  reconnect_wait_time(reconnect_wait_time),
+  conductor_mutex()
+{
+    boost::lock_guard<boost::mutex> lock(conductor_mutex);
+    open(false);
+}
+
+ResilientSender::~ResilientSender() {
+    close();
+}
+
+void ResilientSender::close() {
+    sender.reset(0);
+}
+
+void ResilientSender::open(bool wait_first) {
+    while(sender.get() == 0) {
+        try {
+            if (wait_first) {
+                NOVA_LOG_INFO("Waiting to create fresh AMQP connection...");
+                boost::posix_time::seconds time(reconnect_wait_time);
+                boost::this_thread::sleep(time);
+            }
+            AmqpConnectionPtr connection =
+                AmqpConnection::create(host.c_str(), port, userid.c_str(),
+                    password.c_str(), client_memory);
+            sender.reset(new Sender(connection, topic.c_str()));
+
+            return;
+        } catch(const AmqpException & amqpe) {
+            NOVA_LOG_ERROR("Error establishing AMQP connection: %s",
+                            amqpe.what());
+            wait_first = true;
+        }
+    }
+}
+
+void ResilientSender::reset() {
+    close();
+    open(true);
+}
+
+void ResilientSender::send(const char * publish_string) {
+    boost::lock_guard<boost::mutex> lock(conductor_mutex);
+    try {
+        sender->send(publish_string);
+    } catch(const AmqpException & amqpe) {
+        NOVA_LOG_ERROR("Error with AMQP connection! : %s", amqpe.what());
+        reset();
+    }
+}
+
+void ResilientSender::send(const JsonObject & publish_object) {
+    boost::lock_guard<boost::mutex> lock(conductor_mutex);
+    try {
+        sender->send(publish_object);
+    } catch(const AmqpException & amqpe) {
+        NOVA_LOG_ERROR("Error with AMQP connection! : %s", amqpe.what());
+        reset();
+    }
+}

--- a/src/nova/rpc/amqp.cc
+++ b/src/nova/rpc/amqp.cc
@@ -500,7 +500,7 @@ AmqpQueueMessagePtr AmqpChannel::get_message(const char * queue_name) {
         // I've seen in cases where an empty pointer is returned here that the
         // next message, when read, has a decoded pointer to 0x22 (not null,
         // but still garbage). So the best solution is throw an exception.
-        // The resilent receiver will open a new connection and things will
+        // The resilient receiver will open a new connection and things will
         // proceed smoothly from there.
         throw AmqpException(AmqpException::UNEXPECTED_FRAME_PAYLOAD_METHOD);
     }

--- a/src/nova/rpc/receiver.h
+++ b/src/nova/rpc/receiver.h
@@ -46,14 +46,14 @@ namespace nova { namespace rpc {
 
     /** Like the standard receiver, but kills and waits to restablish
      *  the connection anytime there's a problem. */
-    class ResilentReceiver {
+    class ResilientReceiver {
 
     public:
-        ResilentReceiver(const char * host, int port, const char * userid,
+        ResilientReceiver(const char * host, int port, const char * userid,
             const char * password, size_t client_memory, const char * topic,
             const char * exchange_name, unsigned long reconnect_wait_time);
 
-        ~ResilentReceiver();
+        ~ResilientReceiver();
 
         /** Finishes a message. */
         void finish_message(const nova::guest::GuestOutput & output);
@@ -64,8 +64,8 @@ namespace nova { namespace rpc {
         void reset();
 
     private:
-        ResilentReceiver(const ResilentReceiver &);
-        ResilentReceiver & operator = (const ResilentReceiver &);
+        ResilientReceiver(const ResilientReceiver &);
+        ResilientReceiver & operator = (const ResilientReceiver &);
 
         size_t client_memory;
 

--- a/src/nova/rpc/sender.h
+++ b/src/nova/rpc/sender.h
@@ -3,8 +3,13 @@
 
 #include "nova/rpc/amqp_ptr.h"
 #include <json/json.h>
+#include "nova/guest/guest.h"
 #include "nova/Log.h"
+#include <memory>
+#include <boost/optional.hpp>
+#include <string>
 #include <boost/utility.hpp>
+#include <boost/smart_ptr.hpp>
 
 namespace nova { namespace rpc {
 
@@ -27,6 +32,51 @@ namespace nova { namespace rpc {
             const std::string queue_name;
             const std::string routing_key;
     };
+
+    class ResilientSender {
+        public:
+            ResilientSender(const char * host, int port, const char * userid,
+                const char * password, size_t client_memory, const char * topic,
+                const char * exchange_name, unsigned long reconnect_wait_time);
+
+            ~ResilientSender();
+
+            void send(const JsonObject & object);
+
+            void send(const char * publish_string);
+
+        private:
+            ResilientSender(const ResilientSender &);
+            ResilientSender & operator = (const ResilientSender &);
+
+            void reset();
+
+            size_t client_memory;
+
+            void close();
+
+            std::string exchange_name;
+
+            std::string host;
+
+            void open(bool wait_first);
+
+            std::string password;
+
+            int port;
+
+            std::auto_ptr<Sender> sender;
+
+            std::string topic;
+
+            std::string userid;
+
+            unsigned long reconnect_wait_time;
+
+            boost::mutex conductor_mutex;
+    };
+
+    typedef boost::shared_ptr<ResilientSender> ResilientSenderPtr;
 
 } }  // end namespace
 

--- a/src/send_forever.cc
+++ b/src/send_forever.cc
@@ -1,0 +1,53 @@
+#include "nova/Log.h"
+#include "nova/rpc/sender.h"
+#include <boost/format.hpp>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace boost;
+using nova::JsonData;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+
+// Repeatedly send messages to the queue.
+// ./send_forever guest f7999d1955c5014aa32c guest restests
+
+//using namespace nova;
+using namespace nova::rpc;
+
+int main(int argc, char **argv)
+{
+  LogApiScope log(LogOptions::simple());
+
+  if (argc < 4) {
+    cerr << "Usage: send_forever <user> <password> <topic> <exchange>" << endl;
+    return 1;
+  }
+
+  int i = 0;
+  const char * userid = argv[++i];
+  const char * password = argv[++i];
+  const char * topic = argv[++i];
+  const char * exchange = argv[++i];
+
+  const int sleep_seconds = 10;
+
+  const char * MESSAGE = "{\"oslo.message\": \"{"
+                             "\\\"method\\\": \\\"forever\\\", "
+                             "\\\"args\\\": {}}\"}";
+
+  ResilientSender sender("localhost", 5672, userid, password, 4096, topic, exchange, 10);
+
+  while(true){
+        sender->send(MESSAGE);
+        sleep(sleep_seconds);
+  }
+
+  return 0;
+}

--- a/src/send_forever_turbo.cc
+++ b/src/send_forever_turbo.cc
@@ -1,0 +1,104 @@
+#include "pch.hpp"
+#include "nova/guest/agent.h"
+#include "nova/guest/guest.h"
+#include "nova/rpc/sender.h"
+#include "nova/flags.h"
+#include <boost/tuple/tuple.hpp>
+
+
+using nova::guest::agent::execute_main;
+using namespace nova::flags;
+using namespace nova::guest;
+using namespace nova::db::mysql;
+using namespace nova::rpc;
+using nova::utils::ThreadBasedJobRunner;
+using std::vector;
+using nova::JsonData;
+using nova::JsonDataPtr;
+using nova::JsonObject;
+using nova::JsonObjectPtr;
+
+// Begin anonymous namespace.
+namespace {
+
+static bool quit;
+
+
+class ListenForQuit: public MessageHandler
+{
+    JsonDataPtr handle_message(const GuestInput & input)
+    {
+        std::string m(input.method_name);
+        if (m == "quit") {
+            quit = true;
+        }
+        return JsonData::from_null();
+    }    
+};
+
+
+struct EmptyAppUpdate {
+    void update() {
+    }
+};
+
+typedef boost::shared_ptr<EmptyAppUpdate> EmptyAppUpdatePtr;
+
+
+void SendMessages(ResilientSenderPtr sender) {
+    std::string HELLO = "{\"oslo.message\": \"{"
+                            "\\\"method\\\": \\\"hello\\\", "
+                            "\\\"args\\\": {}}\"}";
+
+    while(!quit) {
+        sender->send(HELLO.c_str());
+    }
+    NOVA_LOG_INFO("I am quitting.")
+}
+
+
+struct Func {
+
+    typedef boost::shared_ptr <boost::thread> thread_ptr;
+    vector<thread_ptr> threads;
+
+    boost::tuple<vector<MessageHandlerPtr>, EmptyAppUpdatePtr>
+        operator() (const FlagValues & flags,
+                    MySqlConnectionWithDefaultDbPtr & nova_db,
+                    ThreadBasedJobRunner & job_runner)
+
+    {
+        quit = false;
+        std::string topic = str(boost::format("guestagent.%s") % flags.guest_id());
+
+        ResilientSenderPtr sender(
+            new ResilientSender(
+                flags.rabbit_host(), flags.rabbit_port(),
+                flags.rabbit_userid(), flags.rabbit_password(),
+                flags.rabbit_client_memory(),
+                topic.c_str(), flags.control_exchange(),
+                flags.rabbit_reconnect_wait_time()));
+
+        const int worker_count = 10;
+        for (int i = 0; i < worker_count; i++) {
+            thread_ptr ptr(new boost::thread(SendMessages, sender));
+            threads.push_back(ptr);
+        }
+
+        vector<MessageHandlerPtr> handlers;
+        MessageHandlerPtr chill(new ListenForQuit());
+        handlers.push_back(chill);
+
+        EmptyAppUpdatePtr updater(new EmptyAppUpdate());
+
+        return boost::make_tuple(handlers, updater);
+    }
+
+};
+
+} // end anonymous namespace
+
+
+int main(int argc, char* argv[]) {
+    return execute_main<Func, EmptyAppUpdatePtr>("Send Forever Turbo", argc, argv);
+}

--- a/src/send_to_conductor.cc
+++ b/src/send_to_conductor.cc
@@ -1,0 +1,43 @@
+#include "nova/Log.h"
+#include "nova/rpc/sender.h"
+#include <boost/format.hpp>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace boost;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+
+// Send messages directly to Conductor.
+// ./send_to_conductor guest f7999d1955c5014aa32c '{"method": "heartbeat", "args": {"instance_id": "4f313363-2db9-4a8d-9843-db8bf1205410", "payload": {"service_status": "running"}}}'
+
+//using namespace nova;
+using namespace nova::rpc;
+
+int main(int argc, char **argv)
+{
+  LogApiScope log(LogOptions::simple());
+
+  if (argc < 3) {
+    cerr << "Usage: send_to_conductor <user> <password> <message>" << endl;
+    return 1;
+  }
+
+  int i = 0;
+  const char * userid = argv[++i];
+  const char * password = argv[++i];
+  const char * message = argv[++i];
+
+  ResilientSender rs("10.0.0.1", 5672,
+                     userid, password,
+                     4096, "trove-conductor","", 10);
+  rs.send(message);
+
+  return 0;
+}

--- a/src/sfturbo_recv.cc
+++ b/src/sfturbo_recv.cc
@@ -1,0 +1,64 @@
+#include "pch.hpp"
+#include "nova/guest/agent.h"
+#include "nova/guest/guest.h"
+#include "nova/flags.h"
+#include <boost/tuple/tuple.hpp>
+
+
+using nova::guest::agent::execute_main;
+using namespace nova::flags;
+using namespace nova::guest;
+using namespace nova::db::mysql;
+using namespace nova::rpc;
+using nova::utils::ThreadBasedJobRunner;
+using std::vector;
+using nova::JsonData;
+using nova::JsonDataPtr;
+using nova::JsonObject;
+using nova::JsonObjectPtr;
+
+// Begin anonymous namespace.
+namespace {
+
+class IgnoreEverything: public MessageHandler
+{
+    JsonDataPtr handle_message(const GuestInput & input)
+    { return JsonData::from_null(); }    
+};
+
+
+struct EmptyAppUpdate { void update() { } };
+
+typedef boost::shared_ptr<EmptyAppUpdate> EmptyAppUpdatePtr;
+
+
+struct Func {
+
+    typedef boost::shared_ptr <boost::thread> thread_ptr;
+    vector<thread_ptr> threads;
+
+    boost::tuple<vector<MessageHandlerPtr>, EmptyAppUpdatePtr>
+        operator() (const FlagValues & flags,
+                    MySqlConnectionWithDefaultDbPtr & nova_db,
+                    ThreadBasedJobRunner & job_runner)
+
+    {
+        std::string topic = str(boost::format("guestagent.%s") % flags.guest_id());
+
+        vector<MessageHandlerPtr> handlers;
+        MessageHandlerPtr chill(new IgnoreEverything());
+        handlers.push_back(chill);
+
+        EmptyAppUpdatePtr updater(new EmptyAppUpdate());
+
+        return boost::make_tuple(handlers, updater);
+    }
+
+};
+
+} // end anonymous namespace
+
+
+int main(int argc, char* argv[]) {
+    return execute_main<Func, EmptyAppUpdatePtr>("SF Turbo RECV", argc, argv);
+}

--- a/src/sfturbo_send.cc
+++ b/src/sfturbo_send.cc
@@ -1,0 +1,93 @@
+#include "pch.hpp"
+#include "nova/guest/agent.h"
+#include "nova/guest/guest.h"
+#include "nova/rpc/sender.h"
+#include "nova/flags.h"
+#include "nova/Log.h"
+#include <boost/tuple/tuple.hpp>
+
+
+using nova::guest::agent::execute_main;
+using namespace nova::flags;
+using namespace nova::guest;
+using namespace nova::db::mysql;
+using namespace nova::rpc;
+using nova::utils::ThreadBasedJobRunner;
+using std::vector;
+using nova::JsonData;
+using nova::JsonDataPtr;
+using nova::JsonObject;
+using nova::JsonObjectPtr;
+using nova::LogOptions;
+using nova::LogFileOptions;
+
+// Begin anonymous namespace.
+namespace {
+
+void SendMessages(ResilientSenderPtr sender) {
+    std::string HELLO = "{\"oslo.message\": \"{"
+                            "\\\"method\\\": \\\"TURBO\\\", "
+                            "\\\"args\\\": {}}\"}";
+
+    while(true) {
+        try {
+        NOVA_LOG_INFO("Sending a HELLO.");
+        sender->send(HELLO.c_str());
+        } catch (std::exception ex) {
+            NOVA_LOG_ERROR("Exception! %s", ex.what());
+            throw ex;
+        }
+    }
+}
+
+
+LogOptions log_options_from_flags(const FlagValues & flags) {
+    boost::optional<LogFileOptions> log_file_options;
+    if (flags.log_file_path()) {
+        LogFileOptions ops(flags.log_file_path().get(),
+                           flags.log_file_max_size(),
+                           flags.log_file_max_time(),
+                           flags.log_file_max_old_files().get_value_or(30));
+        log_file_options = boost::optional<LogFileOptions>(ops);
+    } else {
+        log_file_options = boost::none;
+    }
+    LogOptions log_options(log_file_options,
+                           flags.log_use_std_streams(),
+                           flags.log_show_trace());
+    return log_options;
+}
+
+} // end anonymous namespace
+
+int main(int argc, char* argv[]) {
+    FlagValues flags(
+        nova::flags::FlagMap::create_from_args(argc, argv, true));
+
+    LogOptions log_options = log_options_from_flags(flags);
+    nova::LogApiScope log_api_scope(log_options);
+
+
+    typedef boost::shared_ptr <boost::thread> thread_ptr;
+    vector<thread_ptr> threads;
+    
+    std::string topic = str(boost::format("guestagent.%s") % flags.guest_id());
+
+    ResilientSenderPtr sender(
+        new ResilientSender(
+            flags.rabbit_host(), flags.rabbit_port(),
+            flags.rabbit_userid(), flags.rabbit_password(),
+            flags.rabbit_client_memory(),
+            topic.c_str(), flags.control_exchange(),
+            flags.rabbit_reconnect_wait_time()));
+
+    const int worker_count = 10;
+    for (int i = 0; i < worker_count; i++) {
+        thread_ptr ptr(new boost::thread(SendMessages, sender));
+        threads.push_back(ptr);
+    }
+
+    while(true){}
+
+    return 0;
+}

--- a/tests/resilient_tests.cc
+++ b/tests/resilient_tests.cc
@@ -1,0 +1,166 @@
+#define BOOST_TEST_MODULE Conductor_Stress_Tests
+#include <boost/test/unit_test.hpp>
+
+#include "nova/rpc/amqp.h"
+#include <boost/date_time.hpp>
+#include "nova/flags.h"
+#include <boost/thread.hpp>
+#include "nova/rpc/receiver.h"
+#include "nova/rpc/sender.h"
+#include "nova/db/mysql.h"
+#include <boost/format.hpp>
+#include <string>
+#include <stdlib.h>
+#include <memory>
+
+#define CHECK_POINT() BOOST_CHECK_EQUAL(2,2); NOVA_LOG_DEBUG("At line %d...", __LINE__);
+using nova::flags::FlagMap;
+using nova::flags::FlagMapPtr;
+using nova::flags::FlagValues;
+using nova::JsonData;
+using nova::JsonObject;
+using nova::JsonObjectPtr;
+using namespace nova::guest;
+using nova::Log;
+using nova::LogApiScope;
+using nova::LogOptions;
+using namespace nova::rpc;
+using boost::posix_time::milliseconds;
+using boost::posix_time::time_duration;
+using boost::thread;
+using boost::format;
+using std::vector;
+
+
+namespace {
+    const char * TOPIC = "guest";
+
+    FlagMapPtr get_flags() {
+        FlagMapPtr ptr(new FlagMap());
+        char * test_args = getenv("TEST_ARGS");
+        BOOST_REQUIRE_MESSAGE(test_args != 0, "TEST_ARGS environment var not defined.");
+        if (test_args != 0) {
+            ptr->add_from_arg(test_args);
+        }
+        return ptr;
+    }
+
+}
+
+static std::string rabbitmq_host;
+
+const char * host() {
+    const char * value = getenv("AMQP_HOST");
+    if (value != 0) {
+        rabbitmq_host = value;
+    } else {
+        rabbitmq_host = "localhost";
+    }
+    return rabbitmq_host.c_str();
+}
+
+struct GlobalFixture {
+
+    LogApiScope log;
+
+    GlobalFixture()
+    : log(LogOptions::simple()) {
+    }
+
+};
+
+
+struct SenderWorker {
+    ResilientSenderPtr sender;
+    int threadid;
+    int count;
+
+    SenderWorker(ResilientSenderPtr sender, int threadid, int count)
+    :
+    sender(sender),
+    threadid(threadid),
+    count(count)
+    {}
+
+    void work() {
+        const char * MESSAGE = "{\"oslo.message\": \"{"
+                                   "\\\"method\\\": \\\"testing\\\", "
+                                   "\\\"args\\\": {"
+                                       "\\\"order\\\": %d, "
+                                       "\\\"thread\\\": %d"
+                                       "}}\"}";
+        
+        for (int i=0; i<count; i++){
+            std::string msg = str(format(MESSAGE) % i % threadid);
+            sender->send(msg.c_str());
+        }
+    }
+};
+
+
+BOOST_GLOBAL_FIXTURE(GlobalFixture);
+
+BOOST_AUTO_TEST_CASE(SendingSomeMessages)
+{
+    CHECK_POINT();
+    FlagValues flags(get_flags());
+
+    ResilientSenderPtr sender(new ResilientSender(flags.rabbit_host(), flags.rabbit_port(),
+                                                  flags.rabbit_userid(), flags.rabbit_password(),
+                                                  flags.rabbit_client_memory(), TOPIC, "restests", 60));
+
+    NOVA_LOG_INFO("TEST - Created RSender");
+
+    CHECK_POINT();
+
+    ResilientReceiver receiver(flags.rabbit_host(), flags.rabbit_port(), flags.rabbit_userid(), flags.rabbit_password(), flags.rabbit_client_memory(), TOPIC, "restests", 60);
+
+    NOVA_LOG_INFO("TEST - Created RReceiver");
+
+    CHECK_POINT();
+
+    const int worker_count = 10;
+    typedef boost::shared_ptr <boost::thread> thread_ptr;
+    vector<thread_ptr> threads;
+    vector<SenderWorker> workers;
+
+    const int message_count = 1000;
+    for (int t = 0; t < worker_count; t ++) {
+        workers.push_back(SenderWorker(sender, t, message_count));
+    }
+    for (int i = 0; i < worker_count; i ++) {
+        CHECK_POINT();
+        thread_ptr ptr(new boost::thread(&SenderWorker::work, &workers[i]));
+        threads.push_back(ptr);
+    }
+
+    CHECK_POINT();
+    const int total_messages = worker_count * message_count;
+    vector<int> seen;
+    for (int t=0; t<worker_count; t++){
+        seen.push_back(0);
+    }
+    for (int message=0; message<total_messages; message++){
+        GuestInput input = receiver.next_message();
+
+        BOOST_CHECK_EQUAL("testing", input.method_name);
+        int t = input.args->get_int("thread");
+        int o = input.args->get_int("order");
+        seen[t]++;
+
+        BOOST_CHECK_EQUAL(o, o);
+        NOVA_LOG_INFO("Saw thread %i, order %i.", t, o);
+
+        GuestOutput output;
+        output.failure = boost::none;
+        output.result = JsonData::from_string("ok");
+
+        receiver.finish_message(output);
+    }
+
+    for (int t=0; t<worker_count; t++) {
+        NOVA_LOG_INFO("Seen count for %i: %i", t, seen[t]);
+        BOOST_CHECK_EQUAL(seen[t], message_count);
+    }
+    
+}


### PR DESCRIPTION
Corrects spelling of "Resilent" to "Resilient" where applicable.
Guest Agent now uses Conductor to update status, instead of db connection.
Instead of backup_id, backup_info is passed to agent.
send_to_conductor will send a message to conductor on the host.
With this commit the host database requirement is not yet removed.
