### PR TITLE
Change volume filesystem total and free to GB

### DIFF
--- a/src/nova/guest/diagnostics.h
+++ b/src/nova/guest/diagnostics.h
@@ -44,8 +44,8 @@ namespace nova { namespace guest { namespace diagnostics {
         unsigned long block_size;
         unsigned long total_blocks;
         unsigned long free_blocks;
-        unsigned long total;
-        unsigned long free;
+        float total;
+        float free;
         float used;
     };
 

--- a/src/nova/guest/diagnostics/Interrogator.cc
+++ b/src/nova/guest/diagnostics/Interrogator.cc
@@ -218,10 +218,13 @@ FileSystemStatsPtr Interrogator::get_filesystem_stats(std::string fs_path) {
         fs_stats->block_size = stats_buf.f_bsize;
         fs_stats->total_blocks = stats_buf.f_blocks;
         fs_stats->free_blocks = stats_buf.f_bfree;
-        fs_stats->total = fs_stats->total_blocks * fs_stats->block_size;
-        fs_stats->free = fs_stats->free_blocks * fs_stats->block_size;
-        unsigned long used_bytes = fs_stats->total - fs_stats->free;
+        unsigned long total_bytes =  fs_stats->total_blocks * fs_stats->block_size;
+        unsigned long free_bytes = fs_stats->free_blocks * fs_stats->block_size;
+        unsigned long used_bytes = total_bytes - free_bytes;
+        // Convert used, free, total to GBs
         fs_stats->used = used_bytes / BYTES2GB;
+        fs_stats->free = free_bytes / BYTES2GB;
+        fs_stats->total = total_bytes / BYTES2GB;
         return fs_stats;
     } else {
         throw InterrogatorException(InterrogatorException::FILESYSTEM_NOT_FOUND);

--- a/tests/nova/guest/diag_tests.cc
+++ b/tests/nova/guest/diag_tests.cc
@@ -56,12 +56,12 @@ BOOST_AUTO_TEST_CASE(get_filesystem_stats)
     oss << "Total Blocks: " << stats->total_blocks << ", ";
     oss << "Free Blocks: " << stats->free_blocks << "\n";
     oss << "Total: " << stats->total << ", Used: " << stats->used << ", Free: " << stats->free;
-    float mbs_in_gb = mb / BYTES2GB; 
+    float mbs_in_gb = mb / BYTES2GB;
     NOVA_LOG_DEBUG(oss.str().c_str());
     BOOST_CHECK(stats->block_size > 0);
     BOOST_CHECK(stats->total_blocks > 0);
     BOOST_CHECK(stats->free_blocks > 0);
-    BOOST_CHECK(stats->total > mb);
-    BOOST_CHECK(stats->free > mb);
+    BOOST_CHECK(stats->total > mbs_in_gb);
+    BOOST_CHECK(stats->free > mbs_in_gb);
     BOOST_CHECK(stats->used > mbs_in_gb);
 }


### PR DESCRIPTION
Previously filesystsem total and free attributes were returned as
block sizes (ints).  Now they will be returned as GB size as floats.
