### PR TITLE
Fixing memory leak.

### DIFF
--- a/src/nova/guest/backup/BackupManager.h
+++ b/src/nova/guest/backup/BackupManager.h
@@ -16,7 +16,7 @@
 namespace nova { namespace guest { namespace backup {
 
 
-    class BackupManager : boost::noncopyable {
+    class BackupManager {
         public:
             BackupManager(
                    nova::db::mysql::MySqlConnectionWithDefaultDbPtr & infra_db,

--- a/src/nova/guest/backup/BackupMessageHandler.h
+++ b/src/nova/guest/backup/BackupMessageHandler.h
@@ -18,7 +18,7 @@ namespace nova { namespace guest { namespace backup {
           BackupMessageHandler(const BackupMessageHandler &);
           BackupMessageHandler & operator = (const BackupMessageHandler &);
 
-          BackupManager & backup_manager;
+          BackupManager backup_manager;
     };
 
 } } }  // end namespace

--- a/src/nova/guest/mysql/MySqlMessageHandler.h
+++ b/src/nova/guest/mysql/MySqlMessageHandler.h
@@ -57,7 +57,7 @@ namespace nova { namespace guest { namespace mysql {
 
         private:
             nova::guest::apt::AptGuestPtr apt;
-            nova::guest::monitoring::Monitoring & monitoring;
+            nova::guest::monitoring::Monitoring monitoring;
             MySqlAppPtr mysqlApp;
             VolumeManagerPtr volumeManager;
     };


### PR DESCRIPTION
The BackupManager was originally created on the stack
of the main method, which was ok as it could live there
forever.

With my recent changes however this method no longer
persisted, and unfortunately some Json RPC marshallers
held references (this was dumb). Changing these to be
full copies fixed everything.
