### PR TITLE
Fix VolumeManager shared_ptr

### DIFF
--- a/src/mysql_agent.cc
+++ b/src/mysql_agent.cc
@@ -120,8 +120,9 @@ struct Func {
           * message handler. */
         VolumeManagerPtr volumeManager;
         if (flags.volume_format_and_mount()) {
-          /* Create Volume Manager. */
-          VolumeManagerPtr volumeManager(new VolumeManager(
+          /** Create Volume Manager.
+            * Reset null pointer to reference VolumeManager */
+          volumeManager.reset(new VolumeManager(
             flags.volume_check_device_num_retries(),
             flags.volume_file_system_type(),
             flags.volume_format_options(),


### PR DESCRIPTION
The volume manager shared pointer was not being set correctly if
mounting/formatting volumes was enabled.  It was just being left as a
null pointer, which should only be the case if not enabled.
