### PR TITLE
Fix wheezy libstdc not found error

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -55,7 +55,16 @@ cpp-pch pch
 # will quietly give you a bigger executable. Exciting!
 # The solution is "-static-libgcc" along with some of the stranger flags
 # seen below.
-local EXE_LINK_FLAGS = " -static-libgcc -L/home/vagrant/. -L/lib/. -L/usr/lib/gcc/x86_64-linux-gnu/4.4.3/. -lpthread -ldl" ;
+#
+# Debian wheezy has a newer version of gcc (4.7) with '-static-libstdc++'
+
+local WHEEZY = SHELL "cat /etc/*-release | grep wheezy" ;
+local EXE_LINK_FLAGS = "" ;
+if $(WHEEZY) != "" {
+    EXE_LINK_FLAGS = " -static-libstdc++ -L/home/vagrant/. -L/lib/. -L/usr/lib/gcc/x86_64-linux-gnu/4.7/. -pthread -ldl" ;
+} else {
+    EXE_LINK_FLAGS = " -static-libgcc -L/home/vagrant/. -L/lib/. -L/usr/lib/gcc/x86_64-linux-gnu/4.4.3/. -lpthread -ldl" ;
+}
 
 ###############################################################################
 #       Dependencies


### PR DESCRIPTION
The nova-guest does not run due to the following error:

nova-guest: /usr/lib/libstdc++.so.6: version `GLIBCXX_3.4.15' not
found (required by nova-guest)
- Since wheezy comes with a newer version of gcc, we can use a new
  gcc flag '-static-libstdc++' introduced in 4.5.
- Also the newer  gcc version is used
- lpthread is now pthread
