### PR TITLE
Change mount_point to string from rpc payload

### DIFF
--- a/src/mysql_agent.cc
+++ b/src/mysql_agent.cc
@@ -166,6 +166,7 @@ struct Func {
             flags.volume_file_system_type(),
             flags.volume_format_options(),
             flags.volume_format_timeout(),
+            "/var/lib/mysql",
             flags.volume_mount_options()
           ));
         }

--- a/src/nova/VolumeManager.cc
+++ b/src/nova/VolumeManager.cc
@@ -320,11 +320,13 @@ VolumeManager::VolumeManager(
     const std::string & volume_fstype,
     const std::string & format_options,
     const unsigned int volume_format_timeout,
+    const std::string & mount_point,
     const std::string & mount_options)
 :   num_tries_device_exists(num_tries_device_exists),
     volume_fstype(volume_fstype),
     format_options(format_options),
     volume_format_timeout(volume_format_timeout),
+    mount_point(mount_point),
     mount_options(mount_options)
 {
 }
@@ -346,6 +348,10 @@ std::string VolumeManager::get_format_options() const {
 
 unsigned int VolumeManager::get_volume_format_timeout() const {
     return volume_format_timeout;
+}
+
+std::string VolumeManager::get_mount_point() const {
+    return mount_point;
 }
 
 std::string VolumeManager::get_mount_options() const {

--- a/src/nova/VolumeManager.h
+++ b/src/nova/VolumeManager.h
@@ -69,6 +69,7 @@ public:
                   const std::string & volume_fstype,
                   const std::string & format_options,
                   const unsigned int volume_format_timeout,
+                  const std::string & mount_point,
                   const std::string & mount_options);
 
     ~VolumeManager();
@@ -81,6 +82,8 @@ public:
 
     unsigned int get_volume_format_timeout() const;
 
+    std::string get_mount_point() const;
+
     std::string get_mount_options() const;
 
     VolumeDevice create_volume_device(const std::string device_path);
@@ -92,6 +95,7 @@ private:
     const std::string volume_fstype;
     const std::string format_options;
     const unsigned int volume_format_timeout;
+    const std::string mount_point;
     const std::string mount_options;
 };
 

--- a/src/nova/guest/diagnostics/InterrogatorMessageHandler.cc
+++ b/src/nova/guest/diagnostics/InterrogatorMessageHandler.cc
@@ -68,8 +68,8 @@ JsonDataPtr InterrogatorMessageHandler::handle_message(const GuestInput & input)
         }
     } else if (input.method_name == "get_filesystem_stats") {
         NOVA_LOG_DEBUG("handling the get_filesystem_stats method");
-        string fs_path = input.args->get_string("fs_path");
-        FileSystemStatsPtr fs_stats = interrogator.get_filesystem_stats(fs_path);
+        //TODO: Make this configurable.
+        FileSystemStatsPtr fs_stats = interrogator.get_filesystem_stats("/var/lib/mysql");
         JsonDataPtr rtn(new JsonObject(fs_stats_to_json_object(fs_stats)));
         return rtn;
     } else if (input.method_name == "get_hwinfo") {

--- a/src/nova/guest/mysql/MySqlMessageHandler.cc
+++ b/src/nova/guest/mysql/MySqlMessageHandler.cc
@@ -494,14 +494,14 @@ JsonDataPtr MySqlAppMessageHandler::handle_message(const GuestInput & input) {
         // Mount volume
         if (volumeManager) {
             const auto device_path = input.args->get_optional_string("device_path");
-            const auto mount_point = input.args->get_optional_string("mount_point");
+            const auto mount_point = volumeManager->get_mount_point();
             if (device_path && device_path.get().length() > 0) {
                 NOVA_LOG_INFO("Mounting volume for prepare call...");
                 bool write_to_fstab = true;
                 VolumeManagerPtr volume_manager = this->create_volume_manager();
                 VolumeDevice vol_device = volume_manager->create_volume_device(device_path.get());
                 vol_device.format();
-                vol_device.mount(mount_point.get(), write_to_fstab);
+                vol_device.mount(mount_point, write_to_fstab);
                 NOVA_LOG_INFO("Mounted the volume.");
             }
         }
@@ -582,11 +582,11 @@ JsonDataPtr MySqlAppMessageHandler::handle_message(const GuestInput & input) {
         if (volumeManager) {
             bool write_to_fstab = false;
             const auto device_path = input.args->get_optional_string("device_path");
-            const auto mount_point = input.args->get_optional_string("mount_point");
+            const auto mount_point = volumeManager->get_mount_point();
             VolumeManagerPtr volume_manager = this->create_volume_manager();
             VolumeDevice vol_device = volume_manager->create_volume_device(device_path.get());
 
-            vol_device.mount(mount_point.get(), write_to_fstab);
+            vol_device.mount(mount_point, write_to_fstab);
         }
 
         return JsonData::from_null();
@@ -594,11 +594,11 @@ JsonDataPtr MySqlAppMessageHandler::handle_message(const GuestInput & input) {
         NOVA_LOG_INFO("Calling unmount_volume...");
         if (volumeManager) {
             const auto device_path = input.args->get_optional_string("device_path");
-            const auto mount_point = input.args->get_optional_string("mount_point");
+            const auto mount_point = volumeManager->get_mount_point();
             VolumeManagerPtr volume_manager = this->create_volume_manager();
             VolumeDevice vol_device = volume_manager->create_volume_device(device_path.get());
 
-            vol_device.unmount(mount_point.get());
+            vol_device.unmount(mount_point);
         }
 
         return JsonData::from_null();
@@ -606,11 +606,11 @@ JsonDataPtr MySqlAppMessageHandler::handle_message(const GuestInput & input) {
         NOVA_LOG_INFO("Calling resize_fs...");
         if (volumeManager) {
             const auto device_path = input.args->get_optional_string("device_path");
-            const auto mount_point = input.args->get_optional_string("mount_point");
+            const auto mount_point = volumeManager->get_mount_point();
             VolumeManagerPtr volume_manager = this->create_volume_manager();
             VolumeDevice vol_device = volume_manager->create_volume_device(device_path.get());
 
-            vol_device.resize_fs(mount_point.get());
+            vol_device.resize_fs(mount_point);
         }
 
         return JsonData::from_null();


### PR DESCRIPTION
The recent mount_point changes in the public mean that this value
no longer gets sent for volume_info calls. To correct this we now
ignore the mount_point input from Trove entirely and use a string
passed in at the guest agent construction instead.
