### PR TITLE
Adds python script to generate status code

### DIFF
--- a/generate_code.py
+++ b/generate_code.py
@@ -1,0 +1,128 @@
+"""
+Makes sure the annoying strings and integers Sneaky Pete and Trove use to
+communicate stay the same by generating the relevant code for Sneaky Pete.
+
+To do this it takes the path to the .h and .cc files used for Sneaky Pete's
+DatastoreStatus class. There it expects to find a pair of magical string
+values which it dumps the generated source between. They are:
+
+    //! BEGIN GENERATED CODE
+    //! END GENERATED CODE
+
+They only take affect if nothing else outside of spaces appear on the same line.
+"""
+
+import argparse
+import sys
+from trove.common.instance import ServiceStatus
+from trove.common.instance import ServiceStatuses
+
+
+def get_services_enumeration_code():
+    names = [name for name in dir(ServiceStatuses)
+             if not name.startswith("__")]
+    h = []
+    cc = []
+    for index, name in enumerate(names):
+        status = getattr(ServiceStatuses, name)
+        comma = "," if index < len(names) - 1 else ""
+        h.append('                %s = 0x%x%s  // %s\n'
+                 % (name, status.code, comma, status.description))
+        cc.append('        case %s:\n' % name)
+        cc.append('            return "%s";\n'
+                  % status.description.replace('"', '\\"'))
+    return h, cc
+
+
+def splice_lines(original, additional):
+    new = []
+    replay = True
+    for line in original:
+        if line.strip() == "//! END GENERATED CODE":
+            replay = True
+        if replay:
+            new.append(line)
+        if line.strip() == "//! BEGIN GENERATED CODE":
+            replay = False
+            new += additional
+
+    return new
+
+
+def get_sources(args):
+    """
+    Returns the old source code and the new.
+    """
+    with open(args.header_file) as file:
+        h = file.readlines()
+    with open(args.cc_file) as file:
+        cc = file.readlines()
+
+    middle_h, middle_cc = get_services_enumeration_code()
+
+    new_h = splice_lines(h, middle_h)
+    new_cc = splice_lines(cc, middle_cc)
+    return h, cc, new_h, new_cc
+
+
+def lines_are_different(file_type, a, b):
+    for index, line in enumerate(a):
+        if line != b[index]:
+            print("The generated %s file is different." % file_type)
+            print(line)
+            print("\tvs")
+            print(b[index])
+            return True
+    if (len(a) != len(b)):
+        print("The generate %s file has a different line count." % file_type)
+        return True
+    return False
+
+
+def main(args):
+    if not (args.printh or args.printcc or args.replace or args.compare):
+        print("Specify --printh, --printcc, or --replace.")
+        return 1
+    old_h, old_cc, new_h, new_cc = get_sources(args)
+    h = "".join(new_h)
+    cc = "".join(new_cc)
+
+    if args.printh:
+        print(h)
+    if args.printcc:
+        print(cc)
+    if args.compare:
+        if args.replace:
+            printf("--compare and --replace cannot be used together.")
+            return 1
+        if lines_are_different("h", old_h, new_h):
+            return 1
+        elif lines_are_different("cc", old_cc, new_cc):
+            return 1
+        else:
+            print("No new changes.")
+            return 0
+    elif args.replace:
+        with open(args.header_file, 'w') as h_file:
+            h_file.write(h)
+        with open(args.cc_file, 'w') as cc_file:
+            cc_file.write(cc)
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('header_file', help='Header file to generate.')
+    parser.add_argument('cc_file', help='CC file to generate.')
+    parser.add_argument('--printh', help='Show the header file.',
+                        default=False, action='store_true')
+    parser.add_argument('--printcc', help='Show the cc file.',
+                        default=False, action='store_true')
+    parser.add_argument('--replace', help='Replace existing files.',
+                        default=False, action='store_true')
+    parser.add_argument('--compare', help='Check to see if the new version of '
+                        'the files would be different than the current ones. '
+                        'Returns zero if the files are identical and non-zero '
+                        'otherwise. Intended to be used by CI.',
+                        default=False, action='store_true')
+    sys.exit(main(parser.parse_args()))

--- a/src/nova/datastores/DatastoreStatus.cc
+++ b/src/nova/datastores/DatastoreStatus.cc
@@ -119,24 +119,30 @@ void DatastoreStatus::set_status(DatastoreStatus::Status status) {
 const char * DatastoreStatus::status_name(DatastoreStatus::Status status) {
     // Make sure this matches the integers used by Trove!
     switch(status) {
-        case BUILDING:
-            return "building";
+        //! BEGIN GENERATED CODE
         case BLOCKED:
             return "blocked";
-        case PAUSED:
-            return "paused";
+        case BUILDING:
+            return "building";
         case CRASHED:
             return "crashed";
+        case DELETED:
+            return "deleted";
         case FAILED:
-            return "failed";
+            return "failed to spawn";
+        case FAILED_TIMEOUT_GUESTAGENT:
+            return "guestagent error";
+        case NEW:
+            return "new";
+        case PAUSED:
+            return "paused";
         case RUNNING:
             return "running";
         case SHUTDOWN:
             return "shutdown";
-        case NEW:
-            return "new";
         case UNKNOWN:
-            return "unknown_case";
+            return "unknown";
+        //! END GENERATED CODE
         default:
             return "!invalid status code!";
     }

--- a/src/nova/datastores/DatastoreStatus.h
+++ b/src/nova/datastores/DatastoreStatus.h
@@ -39,15 +39,19 @@ namespace nova { namespace datastores {
             /* NOTE: These *MUST* match the values found in
              * trove.instance.models.ServiceStatuses! */
             enum Status {
-                RUNNING = 0x01, // Datastore is active.
-                BLOCKED = 0x02,
-                PAUSED = 0x03,  // Instance is rebooting (this is set in Nova).
-                SHUTDOWN = 0x04, // Datastore is not running.
-                CRASHED = 0x06, // When Datastore died after starting.
-                FAILED = 0x08,
-                BUILDING = 0x09, // Datastore is being installed / prepared.
-                UNKNOWN=0x16,  // Set when the guest becomes unresponsive
-                NEW = 0x17 // Set when the instance is shiny and new.
+                //! BEGIN GENERATED CODE
+                BLOCKED = 0x2,  // blocked
+                BUILDING = 0x9,  // building
+                CRASHED = 0x6,  // crashed
+                DELETED = 0x5,  // deleted
+                FAILED = 0x8,  // failed to spawn
+                FAILED_TIMEOUT_GUESTAGENT = 0x18,  // guestagent error
+                NEW = 0x17,  // new
+                PAUSED = 0x3,  // paused
+                RUNNING = 0x1,  // running
+                SHUTDOWN = 0x4,  // shutdown
+                UNKNOWN = 0x16  // unknown
+                //! END GENERATED CODE
             };
 
             virtual ~DatastoreStatus();


### PR DESCRIPTION
The Trove Service Status maps to the Sneaky Pete DatastoreStatus
type's description strings and integers. This commit introduces a
Python script that runs Trove and generates the relevant source code
to keep this sync'd up. The script also can be run as a test to see
if the source code's values have changed from what's in Trove.
