### PR TITLE
Modify greedy pete for kill 9 signals

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -25,7 +25,9 @@ project
         # The line below makes the Process class print all output.
         <define>_NOVA_PROCESS_VERBOSE
         #TODO: Add  -Wall -Wextra
-        <cxxflags>"-std=c++0x -Werror -Wno-error=strict-aliasing -DNOVA_GUEST_VERSION=\"\\\"$(VERSION_STRING)\\\"\" "
+        #TODO(jcru): Remove '-Wno-error=deprecated-declarations'
+        #            Kept getting auto_ptr deprecated error for greedy_pete.cc
+        <cxxflags>"-std=c++0x -Werror -Wno-error=strict-aliasing -Wno-error=deprecated-declarations -DNOVA_GUEST_VERSION=\"\\\"$(VERSION_STRING)\\\"\" "
         # Enable the very little bit of C++0x functionality available in GCC
         # 4.4.5 and turn warnings into errors except for strict-aliasing, which
         # unfortunatley issues false warnings as verified here:

--- a/src/nova/Log.cc
+++ b/src/nova/Log.cc
@@ -91,6 +91,11 @@ LogOptions LogOptions::simple() {
     return log_options;
 }
 
+LogOptions LogOptions::silent() {
+    LogOptions log_options(boost::none, false, false);
+    return log_options;
+}
+
 
 /**---------------------------------------------------------------------------
  *- LogApiScope

--- a/src/nova/Log.h
+++ b/src/nova/Log.h
@@ -56,6 +56,8 @@ namespace nova {
 
         /** Creates a simple set of LogOptions. Useful for tests. */
         static LogOptions simple();
+
+        static LogOptions silent();
     };
 
     class LogApiScope : boost::noncopyable  {


### PR DESCRIPTION
When greedy pete is running and reaches the max memory allocation it
receives a kill 9 signal which doesn't allow it to write the difference
between start and end diagnostics.

Also added log option for no logs since get_diganostics call logs
every call which we are calling for every memory increment.
