### PR TITLE
Loosen username regex

### DIFF
--- a/src/nova/guest/mysql/MySqlAdmin.cc
+++ b/src/nova/guest/mysql/MySqlAdmin.cc
@@ -43,7 +43,7 @@ namespace {
 }
 
 string extract_user(const string & user) {
-    Regex regex("^'(.+)'@");
+    Regex regex("^'(.*)'@");
     RegexMatchesPtr matches = regex.match(user.c_str());
     if (matches && matches->exists_at(1)) {
         return matches->get(1);
@@ -54,7 +54,7 @@ string extract_user(const string & user) {
 }
 
 string extract_host(const string & user) {
-    Regex regex("^'.+'@'(.+)'");
+    Regex regex("^'.*'@'(.+)'");
     RegexMatchesPtr matches = regex.match(user.c_str());
     if (matches && matches->exists_at(1)) {
         return matches->get(1);

--- a/tests/nova/utils/regex_tests.cc
+++ b/tests/nova/utils/regex_tests.cc
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(sql_pid_file)
 
 BOOST_AUTO_TEST_CASE(match_user_db_assoc)
 {
-    Regex regex("^'(.+)'@");
+    Regex regex("^'(.*)'@");
     RegexMatchesPtr matches = regex.match("'test'@%'");
     BOOST_REQUIRE_EQUAL(!!matches, true);
     BOOST_REQUIRE_EQUAL(matches->get(1), "test");
@@ -103,10 +103,18 @@ BOOST_AUTO_TEST_CASE(match_user_db_assoc)
 
 BOOST_AUTO_TEST_CASE(match_user_db_assoc1)
 {
-    Regex regex("^'(.+)'@");
+    Regex regex("^'(.*)'@");
     RegexMatchesPtr matches = regex.match("'te@st@'@%'");
     BOOST_REQUIRE_EQUAL(!!matches, true);
     BOOST_REQUIRE_EQUAL(matches->get(1), "te@st@");
+}
+
+BOOST_AUTO_TEST_CASE(match_user_db_assoc2)
+{
+    Regex regex("^'(.*)'@");
+    RegexMatchesPtr matches = regex.match("''@%'");
+    BOOST_REQUIRE_EQUAL(!!matches, true);
+    BOOST_REQUIRE_EQUAL(matches->get(1), "");
 }
 
 BOOST_AUTO_TEST_CASE(match_dpkg_output)


### PR DESCRIPTION
MySQL allows a user with an empty string for a name. This user shows up
in Percon Server 5.5.
