### PR TITLE
Add call to .get() to resolve optional string

### DIFF
--- a/src/nova/guest/mysql/MySqlApp.cc
+++ b/src/nova/guest/mysql/MySqlApp.cc
@@ -314,7 +314,7 @@ void MySqlApp::write_fresh_init_file(const string & admin_password,
     boost::optional<std::string> debian_sys_maint_password = fetch_debian_sys_maint_password();
     if (debian_sys_maint_password != boost::none) {
         init_file << "UPDATE mysql.user SET Password=PASSWORD('"
-                  << debian_sys_maint_password << "') "
+                  << debian_sys_maint_password.get() << "') "
                   << "WHERE User='debian-sys-maint';" << std::endl;
     }
 


### PR DESCRIPTION
This data structure changed from string to optional string without
adding the .get() call. The result was instances going into FAILED
state after the debian-sys-maint pwd was set to a wrong value.
