### PR TITLE
Ensure mysql is started before running prepare logic

### DIFF
--- a/src/nova/guest/mysql/MySqlApp.cc
+++ b/src/nova/guest/mysql/MySqlApp.cc
@@ -203,6 +203,10 @@ void MySqlApp::prepare(const string & config_contents,
                        const optional<string> & overrides,
                        optional<BackupRestoreInfo> restore) {
     try {
+
+        NOVA_LOG_INFO("Starting MySQL to ensure it is running...");
+        start_mysql();
+
         NOVA_LOG_INFO("Waiting until we can connect to MySQL...");
         wait_for_initial_connection();
 


### PR DESCRIPTION
Some datastores (percona mysql 5.6) don't start after install. This
is likely related to the StdOutOnly usage as the service starts on
a plain apt-get install. This extra call will ensure that the mysql
service is started with the init script before running through the
prepare logic.
