### PR TITLE
Rely on less hardcoded msgs for redis commands

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -609,6 +609,8 @@ unit u_redis_client
 
 unit u_redis_commands
     :   src/nova/guest/redis/commands.cc
+    :
+    :   tests/nova/redis/CommandsTests.cc
     ;
 
 unit u_redis_config

--- a/src/nova/guest/redis/client.cc
+++ b/src/nova/guest/redis/client.cc
@@ -194,7 +194,7 @@ Response Client::_set_client()
 
 Response Client::_auth()
 {
-    if (_commands->password.length() > 0 && !_authed)
+    if (_commands->requires_auth() && !_authed)
     {
         Response res = _send_redis_message(_commands->auth());
         if (res.status != CMESSAGE_SENT_RESPONSE)

--- a/src/nova/guest/redis/commands.cc
+++ b/src/nova/guest/redis/commands.cc
@@ -3,127 +3,95 @@
 #include <boost/lexical_cast.hpp>
 #include <string>
 #include "constants.h"
+#include <boost/format.hpp>
 
+using boost::lexical_cast;
+using std::string;
+using std::stringstream;
 
 namespace nova { namespace redis {
 
-//Local constants.
-
 namespace {
-
-
-static const std::string AUTH_COMMAND = "*2\r\n$4\r\nAUTH\r\n";
-
-static const std::string PING_COMMAND = "*1\r\n$4\r\nPING\r\n";
-
-static const std::string BGSAVE_COMMAND = "*1\r\n$6\r\nBGSAVE\r\n";
-
-static const std::string SAVE_COMMAND  = "*1\r\n$4\r\nSAVE\r\n";
-
-static const std::string LAST_SAVE_COMMAND = "*1\r\n$8\r\nLASTSAVE\r\n";
-
-static const std::string CLIENT_SET_COMMAND = "*3\r\n$6\r\nCLIENT\r\n$7\r\n"
-                                                    "SETNAME\r\n";
-
-static const std::string CONFIG_SET_COMMAND = "*4\r\n$6\r\nCONFIG\r\n$3\r\n"
-                                                  "SET\r\n";
-
-static const std::string CONFIG_GET_COMMAND = "*3\r\n$6\r\nCONFIG\r\n$3\r\n"
-                                                    "GET\r\n";
-
-static const std::string CONFIG_REWRITE_COMMAND = "*2\r\n$6\r\nCONFIG"
-                                                        "\r\n$7\r\nREWRITE\r\n";
-
-static const std::string DSIGN  = "$";
-
-
-}//end anon namespace
-
-
-void Commands::set_commands()
-{
-    if(_config_command.length() >= 1)
-    {
-        std::string formatted_config;
-        formatted_config = CRLF + DSIGN +
-            boost::lexical_cast<std::string>(_config_command.length()) +
-            CRLF + _config_command + CRLF;
-        _config_set = "*4" + formatted_config + "$3\r\nSET\r\n";
-        _config_get = "*3" + formatted_config + "$3\r\nGET\r\n";
-        _config_rewrite = "*2" + formatted_config + "$7\r\nREWRITE\r\n";
+    template<typename T>
+    void build_redis_array(stringstream & cmd,
+                           int & count,
+                           const T arg) {
+        ++ count;
+        const string str_arg = lexical_cast<string>(arg);
+        cmd << "$" << str_arg.length() << "\r\n"
+            << str_arg << "\r\n";
     }
-    else
-    {
-        _config_set = CONFIG_SET_COMMAND;
-        _config_get = CONFIG_GET_COMMAND;
-        _config_rewrite = CONFIG_REWRITE_COMMAND;
+
+    template<typename HeadType, typename... TailTypes>
+    void build_redis_array(stringstream & cmd,
+                           int & count,
+                           const HeadType headArg,
+                           const TailTypes... tailArgs) {
+        build_redis_array(cmd, count, headArg);
+        build_redis_array(cmd, count, tailArgs...);
+    }
+
+    template<typename... Types>
+    string redis_array(const Types... typeArgs) {
+        stringstream cmd;
+        int count = 0;
+        build_redis_array(cmd, count, typeArgs...);
+        const string full_cmd = "*" + lexical_cast<string>(count) + "\r\n"
+                                + cmd.str();
+        return full_cmd;
     }
 }
 
-Commands::Commands(std::string _password, std::string config_command) :
-                   _config_set(), _config_get(), _config_rewrite(),
-                   _config_command(config_command), password(_password)
+Commands::Commands(const string & _password,
+    const boost::optional<string> & config_command)
+:   _config_command(config_command.get_value_or("CONFIG")),
+    password(_password)
 {
-    set_commands();
 }
 
-std::string Commands::auth()
-{
-    if (password.length() <= 0)
-    {
+bool Commands::requires_auth() const {
+    return password.length() > 0;
+}
+
+string Commands::auth() const {
+    if (requires_auth()) {
+        return redis_array("AUTH", password);
+    } else {
         return "";
     }
-    return AUTH_COMMAND + DSIGN +
-        boost::lexical_cast<std::string>(password.length()) +
-        CRLF + password + CRLF;
+
 }
 
-std::string Commands::ping()
-{
-    return PING_COMMAND;
+string Commands::ping() const {
+    return redis_array("PING");
 }
 
-std::string Commands::config_set(std::string key, std::string value)
-{
-    key = DSIGN + boost::lexical_cast<std::string>(key.length()) +
-          CRLF + key + CRLF;
-    value = DSIGN + boost::lexical_cast<std::string>(value.length()) +
-            CRLF + value + CRLF;
-    return _config_set + key + value;
+string Commands::config_set(string key, string value) const {
+    return redis_array(_config_command, "SET", key, value);
 }
 
-std::string Commands::config_get(std::string key)
-{
-    key = DSIGN + boost::lexical_cast<std::string>(key.length()) +
-          CRLF + key + CRLF;
-    return _config_get + key;
+string Commands::config_get(string key) const {
+    return redis_array(_config_command, "GET", key);
 }
 
-std::string Commands::config_rewrite()
-{
-    return _config_rewrite;
+string Commands::config_rewrite() const {
+    return redis_array(_config_command, "REWRITE");
 }
 
-std::string Commands::bgsave()
-{
-    return BGSAVE_COMMAND;
+string Commands::bgsave() const {
+    return redis_array("BGSAVE");
 }
 
-std::string Commands::save()
-{
-    return SAVE_COMMAND;
+string Commands::save() const {
+    return redis_array("SAVE");
 }
 
-std::string Commands::last_save()
-{
-    return LAST_SAVE_COMMAND;
+string Commands::last_save() const {
+    return redis_array("LASTSAVE");
 }
 
-std::string Commands::client_set_name(std::string client_name)
-{
-    return CLIENT_SET_COMMAND + DSIGN +
-           boost::lexical_cast<std::string>(client_name.length()) +
-           CRLF + client_name + CRLF;
+string Commands::client_set_name(string client_name) const {
+    return redis_array("CLIENT", "SETNAME", client_name);
 }
 
 

--- a/src/nova/guest/redis/commands.h
+++ b/src/nova/guest/redis/commands.h
@@ -1,6 +1,8 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
+#include <boost/lexical_cast.hpp>
+#include <boost/optional.hpp>
 #include <string>
 
 
@@ -9,40 +11,35 @@ namespace nova { namespace redis {
 
 class Commands
 {
-    private:
-        std::string _config_set;
-
-        std::string _config_get;
-
-        std::string _config_rewrite;
-
-        std::string _config_command;
-
-        void set_commands();
-
     public:
-        std::string password;
+        Commands(
+            const std::string & _password,
+            const boost::optional<std::string> & config_command = boost::none);
 
-        Commands(std::string _password, std::string config_command);
+        std::string auth() const;
 
-        std::string auth();
+        std::string ping() const;
 
-        std::string ping();
+        std::string config_set(std::string key, std::string value) const;
 
-        std::string config_set(std::string key, std::string value);
+        std::string config_get(std::string key) const;
 
-        std::string config_get(std::string key);
+        std::string config_rewrite() const;
 
-        std::string config_rewrite();
+        std::string bgsave() const;
 
-        std::string bgsave();
+        std::string save() const;
 
-        std::string save();
+        std::string last_save() const;
 
-        std::string last_save();
+        std::string client_set_name(std::string client_name) const;
 
-        std::string client_set_name(std::string client_name);
+        bool requires_auth() const;
 
+    private:
+        const std::string _config_command;
+
+        const std::string password;
 };
 
 

--- a/tests/nova/redis/CommandsTests.cc
+++ b/tests/nova/redis/CommandsTests.cc
@@ -1,0 +1,46 @@
+#define BOOST_TEST_IGNORE_SIGCHLD
+#define BOOST_TEST_MODULE CommandsTests
+#include <boost/test/unit_test.hpp>
+
+#include "nova/guest/redis/commands.h"
+
+using namespace std;
+using namespace nova::redis;
+
+
+BOOST_AUTO_TEST_CASE(CommandsTests) {
+    Commands cmd("12345");
+
+    BOOST_REQUIRE_EQUAL(cmd.auth(),
+                        "*2\r\n$4\r\nAUTH\r\n$5\r\n12345\r\n");
+    BOOST_REQUIRE_EQUAL(cmd.ping(),
+                        "*1\r\n$4\r\nPING\r\n");
+
+    BOOST_REQUIRE_EQUAL(cmd.client_set_name("TIBERIUS"),
+        "*3\r\n"
+        "$6\r\nCLIENT\r\n"
+        "$7\r\nSETNAME\r\n"
+        "$8\r\n"
+        "TIBERIUS\r\n");
+
+    BOOST_REQUIRE_EQUAL(cmd.config_set("key", "value"),
+        "*4\r\n"
+        "$6\r\nCONFIG\r\n"
+        "$3\r\nSET\r\n"
+        "$3\r\nkey\r\n"
+        "$5\r\nvalue\r\n");
+
+    BOOST_REQUIRE_EQUAL(cmd.config_get("key"),
+        "*3\r\n"
+        "$6\r\nCONFIG\r\n"
+        "$3\r\nGET\r\n"
+        "$3\r\nkey\r\n");
+
+    BOOST_REQUIRE_EQUAL(cmd.config_rewrite(),
+        "*2\r\n"
+        "$6\r\nCONFIG\r\n"
+        "$7\r\nREWRITE\r\n");
+
+    //BOOST_REQUIRE_EQUAL(cmd.config_get("HAT"),
+    //    "$3\r\nHAT\r\n")
+}


### PR DESCRIPTION
Changed the command class to rely less on hand-coded messages
