### PR TITLE
Add enable_ssl message handler

### DIFF
--- a/src/nova/datastores/DatastoreApp.h
+++ b/src/nova/datastores/DatastoreApp.h
@@ -53,6 +53,12 @@ namespace nova { namespace datastores {
                 boost::optional<nova::backup::BackupRestoreInfo> restore
             ) = 0;
 
+            virtual void enable_ssl(
+                const std::string & ca_certificate,
+                const std::string & private_key,
+                const std::string & public_key
+            ) = 0;
+
             /** Implements datastore specific code to start the app. */
             virtual void specific_start_app_method() = 0;
 

--- a/src/nova/guest/common/PrepareHandler.cc
+++ b/src/nova/guest/common/PrepareHandler.cc
@@ -114,6 +114,14 @@ void PrepareHandler::prepare(const GuestInput & input) {
         install_packages(*apt, packages);
 
         app->prepare(root_password, config_contents, overrides, restore);
+        JsonObjectPtr ssl_info = input.args->get_optional_object("ssl");
+        if (ssl_info) {
+            app->enable_ssl(
+                ssl_info->get_string("ca_certificate"),
+                ssl_info->get_string("private_key"),
+                ssl_info->get_string("public_key")
+            );
+        }
 
         status->end_install_or_restart();
         NOVA_LOG_INFO("Preparation of datastore finished successfully.");

--- a/src/nova/guest/mysql/MySqlApp.h
+++ b/src/nova/guest/mysql/MySqlApp.h
@@ -38,6 +38,12 @@ class MySqlApp : public nova::datastores::DatastoreApp {
          *  my.cnf. */
         void write_config_overrides(const std::string & overrides_content);
 
+        void write_ssl_files(
+            const std::string & ca_certificate,
+            const std::string & private_key,
+            const std::string & public_key
+        );
+
     protected:
         /** Installs MySql, secures it, and possibly runs a backup. */
         virtual void prepare(
@@ -45,6 +51,12 @@ class MySqlApp : public nova::datastores::DatastoreApp {
             const std::string & config_contents,
             const boost::optional<std::string> & overrides,
             boost::optional<nova::backup::BackupRestoreInfo> restore
+        );
+
+        virtual void enable_ssl(
+            const std::string & ca_certificate,
+            const std::string & private_key,
+            const std::string & public_key
         );
 
         virtual void specific_start_app_method();

--- a/src/nova/guest/mysql/MySqlGuestException.cc
+++ b/src/nova/guest/mysql/MySqlGuestException.cc
@@ -45,6 +45,8 @@ const char *  MySqlGuestException::code_to_string(Code code) {
             return "Can't create user because no password was specified.";
         case USER_NOT_FOUND:
             return "User not found.";
+        case CANT_WRITE_TMP_FILE:
+            return "Can't write temporary file.";
         default:
             return "MySqlGuest failure.";
     }

--- a/src/nova/guest/mysql/MySqlGuestException.h
+++ b/src/nova/guest/mysql/MySqlGuestException.h
@@ -22,7 +22,8 @@ namespace nova { namespace guest { namespace mysql {
                 INVALID_ZERO_LIMIT,
                 MYSQL_NOT_STOPPED,
                 NO_PASSWORD_FOR_CREATE_USER,
-                USER_NOT_FOUND
+                USER_NOT_FOUND,
+                CANT_WRITE_TMP_FILE
             };
 
             MySqlGuestException(Code code) throw();

--- a/src/nova/guest/mysql/MySqlMessageHandler.cc
+++ b/src/nova/guest/mysql/MySqlMessageHandler.cc
@@ -572,6 +572,17 @@ JsonDataPtr MySqlAppMessageHandler::handle_message(const GuestInput & input) {
         }
 
         return JsonData::from_null();
+
+    } else if (input.method_name == "enable_ssl") {
+        NOVA_LOG_INFO("Calling write_ssl_files.");
+        JsonObjectPtr ssl_info = input.args->get_object("ssl");
+        string private_key = ssl_info->get_string("private_key");
+        string public_key = ssl_info->get_string("public_key");
+        string ca_certificate = ssl_info->get_string("ca_certificate");
+        MySqlAppPtr app = this->create_mysql_app();
+        app->write_ssl_files(ca_certificate, private_key, public_key);
+
+        return JsonData::from_null();
     } else {
         return JsonDataPtr();
     }

--- a/src/nova/redis/RedisApp.cc
+++ b/src/nova/redis/RedisApp.cc
@@ -197,4 +197,10 @@ void RedisApp::write_config(const string & config_contents,
     shell("sudo chmod 644 /etc/redis/redis.conf");
 }
 
+void RedisApp::enable_ssl(const string & ca_certificate, const string & private_key, const string & public_key) {
+
+    return;
+
+}
+
 } }  // end namespace

--- a/src/nova/redis/RedisApp.h
+++ b/src/nova/redis/RedisApp.h
@@ -30,6 +30,12 @@ class RedisApp : public nova::datastores::DatastoreApp {
                 boost::optional<nova::backup::BackupRestoreInfo> restore
             );
 
+        virtual void enable_ssl(
+            const std::string & ca_certificate,
+            const std::string & private_key,
+            const std::string & public_key
+        );
+
         virtual void specific_start_app_method();
 
         virtual void specific_stop_app_method();


### PR DESCRIPTION
This adds an enable_ssl method to the datastore apps to be implemented.
The MySQL implementation drops the key files to a location in /etc/mysql
and drops an extra my.cnf extention with ssl configs.

This also adds a message handler for the mysql message handler to accept
new ssl keys. This handler does not restart the db and can be used to
configure an instance for ssl on existing instances. It will simply
not be available until the instance is restarted.
