### PR TITLE
Stopped doing some things in the Redis client

### DIFF
--- a/src/nova/guest/redis/client.h
+++ b/src/nova/guest/redis/client.h
@@ -25,10 +25,13 @@ class Client
 {
     public:
 
+        /* Creates a new client.
+         * If the host, port, and password aren't given the connection is
+         * made to the standard port on localhost and the Redis config
+         * file is read to determine the password. */
         Client(const boost::optional<std::string> & host=boost::none,
                const boost::optional<int> & port=boost::none,
-               const boost::optional<std::string> & client_name=boost::none,
-               const boost::optional<std::string> & config_file=boost::none);
+               const boost::optional<std::string> & password=boost::none);
 
         ~Client();
 
@@ -53,10 +56,6 @@ class Client
         bool _authed;
 
         bool _auth_required();
-
-        const std::string _client_name;
-
-        const std::string _config_file;
 
         std::unique_ptr<Config> config;
 

--- a/src/nova/guest/redis/commands.cc
+++ b/src/nova/guest/redis/commands.cc
@@ -42,10 +42,8 @@ namespace {
     }
 }
 
-Commands::Commands(const string & _password,
-    const boost::optional<string> & config_command)
-:   _config_command(config_command.get_value_or("CONFIG")),
-    password(_password)
+Commands::Commands(const string & _password)
+:   password(_password)
 {
 }
 
@@ -67,15 +65,15 @@ string Commands::ping() const {
 }
 
 string Commands::config_set(string key, string value) const {
-    return redis_array(_config_command, "SET", key, value);
+    return redis_array("CONFIG", "SET", key, value);
 }
 
 string Commands::config_get(string key) const {
-    return redis_array(_config_command, "GET", key);
+    return redis_array("CONFIG", "GET", key);
 }
 
 string Commands::config_rewrite() const {
-    return redis_array(_config_command, "REWRITE");
+    return redis_array("CONFIG", "REWRITE");
 }
 
 string Commands::bgsave() const {

--- a/src/nova/guest/redis/commands.h
+++ b/src/nova/guest/redis/commands.h
@@ -12,9 +12,7 @@ namespace nova { namespace redis {
 class Commands
 {
     public:
-        Commands(
-            const std::string & _password,
-            const boost::optional<std::string> & config_command = boost::none);
+        Commands(const std::string & _password);
 
         std::string auth() const;
 
@@ -39,7 +37,6 @@ class Commands
         bool requires_auth() const;
 
     private:
-        const std::string _config_command;
 
         const std::string password;
 };

--- a/src/nova/guest/redis/config.cc
+++ b/src/nova/guest/redis/config.cc
@@ -57,7 +57,7 @@ bool Config::_get_bool_value(std::string key)
 }
 
 Config::Config(const optional<string> & config)
-:   _redis_config(config.get_value_or(DEFAULT_REDIS_CONFIG))
+:   _redis_config(config.get_value_or("/etc/redis/redis.conf"))
 {
     std::string line;
     std::string value;
@@ -139,6 +139,7 @@ Config::Config(const optional<string> & config)
     rconfig.close();
 
 }
+
 std::vector<std::string> Config::get_include_files()
 {
     return _include;

--- a/src/nova/guest/redis/constants.h
+++ b/src/nova/guest/redis/constants.h
@@ -60,12 +60,6 @@ static const std::string CMESSAGE_SENT_RESPONSE = "cmessage_sent";
 //This is returned when a command results in no response nothing to parse.
 static const std::string CNOTHING_TO_DO_RESPONSE  = "cnothing";
 
-//Default path to the redis config file
-static const std::string DEFAULT_REDIS_CONFIG = "/etc/redis/redis.conf";
-
-//Default redis agent name for the guestagent.
-static const std::string REDIS_AGENT_NAME = "trove-guestagent";
-
 //Socket error status code.
 static const int SOCK_ERROR = -1;
 

--- a/src/nova/guest/redis/message_handler.cc
+++ b/src/nova/guest/redis/message_handler.cc
@@ -38,8 +38,6 @@ using nova::json_string;
 using boost::optional;
 using namespace std;
 using boost::tie;
-using nova::redis::REDIS_AGENT_NAME;
-using nova::redis::DEFAULT_REDIS_CONFIG;
 using nova::guest::common::PrepareHandlerPtr;
 using nova::redis::REQUIRE_PASS;
 using nova::redis::RedisApp;

--- a/src/nova/redis/RedisBackup.cc
+++ b/src/nova/redis/RedisBackup.cc
@@ -3,7 +3,7 @@
 
 #include "pch.hpp"
 #include "RedisBackup.h"
-#include "RedisBackUpJob.h"
+#include "RedisBackupJob.h"
 #include "nova/guest/redis/client.h"
 
 using nova::backup::BackupInfo;

--- a/src/nova/redis/RedisBackupJob.h
+++ b/src/nova/redis/RedisBackupJob.h
@@ -6,20 +6,20 @@ namespace nova { namespace redis {
 //TODO(tim.simpson): Pretty obvious.
 
 template<typename ClientType>
-class RedisBackUpJob : public nova::utils::Job {
+class RedisBackupJob : public nova::utils::Job {
 public:
     ClientType client;
 
-    RedisBackUpJob()
+    RedisBackupJob()
     : client()
     {
     }
 
-    virtual ~RedisBackUpJob() {
+    virtual ~RedisBackupJob() {
     }
 
     virtual nova::utils::Job * clone() const {
-        return new RedisBackUpJob();
+        return new RedisBackupJob();
     }
 
     // bool bgsave_or_aof_rewrite_ocurring();

--- a/tests/redis_backup_demo.cc
+++ b/tests/redis_backup_demo.cc
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     LogApiScope log(LogOptions::simple());
     CurlScope scope;
 
-    RedisBackUpJob<Client> job;
+    RedisBackupJob<Client> job;
 
     job();
 


### PR DESCRIPTION
The client was looking for the renamed config command, but we ended up
not needing to do this. It also had a config class but that was only
being used in the constructor so I zapped it. Also removed some more
constants from constants.h that were only used in a few places.
