### PR TITLE
Improved ability to send RPC replies

### DIFF
--- a/src/nova/rpc/ResilientConnection.h
+++ b/src/nova/rpc/ResilientConnection.h
@@ -48,7 +48,7 @@ namespace nova { namespace rpc {
 
             int port;
 
-            unsigned int reconnect_wait_time_index = 0;
+            unsigned int reconnect_wait_time_index;
 
             std::vector<unsigned long> reconnect_wait_times;
 


### PR DESCRIPTION
When sending a reply to an RPC method, it's possible that the
initial RPC message with the body Trove cares about is sent but
the "end" message won't be if an exception happens in between.
With the recent improvements to the resilient receiver it turns out
this can be a big problem as it may resend the same bits of the
message over and over, which will be rejected as Trove has already
seen them and doesn't care.

The fix is to make the process of sending this message back stateful
and keep that state outside of the typical connection classes.
