### PR TITLE
Fixing bug that inhibited restores

### DIFF
--- a/src/nova/guest/mysql/MySqlApp.cc
+++ b/src/nova/guest/mysql/MySqlApp.cc
@@ -265,10 +265,10 @@ boost::optional<std::string> fetch_debian_sys_maint_password() {
 }
 
 void MySqlApp::write_fresh_init_file(const string & admin_password,
-                                     bool wipe_root_and_anonymous_users) {
+                                     bool is_not_a_restore) {
     ofstream init_file(FRESH_INIT_FILE_PATH);
 
-    if (wipe_root_and_anonymous_users) {
+    if (is_not_a_restore) {
         NOVA_LOG_INFO("Generating root password...");
         auto new_root_password = mysql::generate_password();
         init_file << "UPDATE mysql.user SET Password=PASSWORD('"
@@ -306,9 +306,11 @@ void MySqlApp::write_fresh_init_file(const string & admin_password,
                   << "WHERE User='debian-sys-maint';" << std::endl;
     }
 
-    NOVA_LOG_INFO("Removing the test default database...");
-    init_file << "DELETE FROM mysql.db WHERE Db IN('test', 'test\\_%');" << std::endl;
-    init_file << "DROP DATABASE test;" << std::endl;
+    if (is_not_a_restore) {
+        NOVA_LOG_INFO("Removing the test default database...");
+        init_file << "DELETE FROM mysql.db WHERE Db IN('test', 'test\\_%');" << std::endl;
+        init_file << "DROP DATABASE test;" << std::endl;
+    }
 
     NOVA_LOG_INFO("Flushing privileges");
     init_file << "FLUSH PRIVILEGES;" << std::endl;

--- a/src/nova/guest/mysql/MySqlApp.h
+++ b/src/nova/guest/mysql/MySqlApp.h
@@ -115,7 +115,7 @@ class MySqlApp : public nova::datastores::DatastoreApp {
          * each command executed as root by MySQL when 'run_mysqld_with_init'
          * is called. */
         void write_fresh_init_file(const std::string & admin_password,
-                                   bool wipe_root_and_anonymous_users);
+                                   bool is_not_a_restore);
         // Loads mysql timezone tables to use named timezones
         void load_timezone_tables(const char *);
 


### PR DESCRIPTION
This bug caused Maria and Percona to not initialize correctly
during a restore since an attempt was made to delete databases
that did not exist. For whatever reason that made the mysqld_safe
process invunerable to attacks from /etc/init.d/mysql stop.
This commit changes the logic to not try to delete those things
during a restore, since in theory they should already be gone.
